### PR TITLE
Improve trade sync and frontend polling

### DIFF
--- a/app/api/v1/trades.py
+++ b/app/api/v1/trades.py
@@ -8,6 +8,7 @@ from ...models.trades import Trade
 from ...models.user import User
 from ...schemas.trades import TradeSchema
 from ...core.auth import get_current_verified_user, get_admin_user
+from ...services.trade_service import TradeService
 
 router = APIRouter()
 
@@ -17,8 +18,16 @@ async def get_user_trades(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_verified_user)
 ):
-    """Ver todos los trades del usuario actual"""
-    trades = db.query(Trade).filter(Trade.user_id == current_user.id).order_by(Trade.opened_at.desc()).all()
+    """Ver todos los trades del usuario actual y refrescar su información"""
+    service = TradeService(db)
+    service.refresh_user_trades(current_user.id)
+
+    trades = (
+        db.query(Trade)
+        .filter(Trade.user_id == current_user.id)
+        .order_by(Trade.opened_at.desc())
+        .all()
+    )
     return trades
 
 
@@ -28,5 +37,11 @@ async def get_all_trades(
     admin_user: User = Depends(get_admin_user)
 ):
     """Ver todos los trades de todos los usuarios (solo admin)"""
+    service = TradeService(db)
+    # Actualizar PnL y estado de todos los trades abiertos agrupados por usuario
+    user_ids = {t.user_id for t in db.query(Trade).filter(Trade.status == 'open').all()}
+    for uid in user_ids:
+        service.refresh_user_trades(uid)
+
     trades = db.query(Trade).order_by(Trade.opened_at.desc()).all()
     return trades

--- a/app/services/trade_service.py
+++ b/app/services/trade_service.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from sqlalchemy.orm import Session
+from ..models.trades import Trade
+from ..integrations.alpaca.client import alpaca_client
+
+
+class TradeService:
+    SYMBOL_MAP = {
+        'BTCUSD': 'BTC/USD',
+        'ETHUSD': 'ETH/USD',
+    }
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.alpaca = alpaca_client
+
+    def _map_symbol(self, symbol: str) -> str:
+        return self.SYMBOL_MAP.get(symbol, symbol)
+
+    def _get_current_price(self, symbol: str) -> float:
+        try:
+            if self.alpaca.is_crypto_symbol(symbol):
+                quote = self.alpaca.get_latest_crypto_quote(symbol)
+                return float(getattr(quote, 'ask_price', getattr(quote, 'ap', 0)))
+            else:
+                quote = self.alpaca.get_latest_quote(symbol)
+                return float(quote.ask_price)
+        except Exception:
+            return 0.0
+
+    def refresh_user_trades(self, user_id: int) -> None:
+        open_trades = self.db.query(Trade).filter(Trade.user_id == user_id, Trade.status == 'open').all()
+        for trade in open_trades:
+            alpaca_symbol = self._map_symbol(trade.symbol)
+            price = self._get_current_price(alpaca_symbol)
+            position = self.alpaca.get_position(alpaca_symbol)
+            if position is None:
+                trade.exit_price = price
+                trade.closed_at = datetime.utcnow()
+                trade.status = 'closed'
+            trade.pnl = (price - trade.entry_price) * trade.quantity
+        self.db.commit()

--- a/frontend/src/pages/trades.tsx
+++ b/frontend/src/pages/trades.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import api from '../services/api';
 
 interface Trade {
   id: number;
@@ -21,18 +22,10 @@ const TradesPage: React.FC = () => {
   useEffect(() => {
     const fetchTrades = async () => {
       try {
-        const token = localStorage.getItem('token');
-        const response = await fetch('http://localhost:8000/api/v1/trades', {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-        });
-
+        const response = await api.trading.getTrades();
         if (!response.ok) {
           throw new Error('Failed to fetch trades');
         }
-
         const data = await response.json();
         setTrades(data);
       } catch (error) {
@@ -43,6 +36,8 @@ const TradesPage: React.FC = () => {
     };
 
     fetchTrades();
+    const interval = window.setInterval(fetchTrades, 30000);
+    return () => clearInterval(interval);
   }, []);
 
   return (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -83,6 +83,10 @@ export const api = {
       return authenticatedFetch(`${API_BASE_URL}/orders`);
     },
 
+    getTrades: async () => {
+      return authenticatedFetch(`${API_BASE_URL}/trades`);
+    },
+
     getPositions: async () => {
       return authenticatedFetch(`${API_BASE_URL}/positions`);
     },


### PR DESCRIPTION
## Summary
- refresh trade data from Alpaca before returning from `/trades`
- allow admin to refresh all open trades
- add service to update trades with latest price and close trades if needed
- expose `getTrades` in API helper and poll every 30s on Trades page

## Testing
- `npm run lint` *(fails: Unexpected any in several files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675c53edf08331859dff82dd63ba4f