### PR TITLE
Fix sell signal error when no account position

### DIFF
--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -111,7 +111,13 @@ class OrderExecutor:
                     print(f"📊 Account position for {correct_symbol}: {account_qty}")
 
                     if account_qty <= 0:
-                        raise ValueError(f"No account position found for {correct_symbol} to sell")
+                        logger.warning(
+                            f"No account position found for {correct_symbol} when processing sell signal"
+                        )
+                        strategy_manager.reset_position(signal.strategy_id, signal.symbol)
+                        raise ValueError(
+                            f"No account position found for {correct_symbol} to sell"
+                        )
 
                     sell_qty = min(strategy_position.quantity, account_qty)
                     signal.quantity = sell_qty

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -110,3 +110,12 @@ class StrategyPositionManager:
         """Obtener cantidad total de un símbolo across todas las estrategias"""
         positions = self.get_all_positions_by_symbol(symbol)
         return sum(pos.quantity for pos in positions)
+
+    def reset_position(self, strategy_id: str, symbol: str) -> None:
+        """Restablecer completamente la posición de una estrategia"""
+        position = self.get_strategy_position(strategy_id, symbol)
+        position.quantity = 0.0
+        position.avg_price = None
+        position.total_invested = 0.0
+        self.db.commit()
+        logger.info(f"Reset position: {strategy_id}:{symbol}")


### PR DESCRIPTION
## Summary
- handle missing account position on sell signals
- add `reset_position` helper to keep strategy state in sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f2837d10833188e6e8e5b3e95f47