### PR TITLE
Add equity curve chart to dashboard

### DIFF
--- a/app/api/v1/trades.py
+++ b/app/api/v1/trades.py
@@ -6,7 +6,7 @@ from typing import List
 from ...database import get_db
 from ...models.trades import Trade
 from ...models.user import User
-from ...schemas.trades import TradeSchema
+from ...schemas.trades import TradeSchema, EquityPointSchema
 from ...core.auth import get_current_verified_user, get_admin_user
 from ...services.trade_service import TradeService
 
@@ -29,6 +29,17 @@ async def get_user_trades(
         .all()
     )
     return trades
+
+
+@router.get("/trades/equity-curve", response_model=List[EquityPointSchema])
+async def get_equity_curve(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Return equity curve points for the current user."""
+    service = TradeService(db)
+    data = service.get_equity_curve(current_user.id)
+    return data
 
 
 @router.get("/admin/all-trades", response_model=List[TradeSchema])

--- a/app/schemas/trades.py
+++ b/app/schemas/trades.py
@@ -21,3 +21,9 @@ class TradeSchema(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class EquityPointSchema(BaseModel):
+    timestamp: datetime
+    equity: float
+

--- a/frontend/src/components/EquityCurveChart.tsx
+++ b/frontend/src/components/EquityCurveChart.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+
+export interface EquityPoint {
+  timestamp: string;
+  equity: number;
+}
+
+const EquityCurveChart: React.FC<{ data: EquityPoint[] }> = ({ data }) => (
+  <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+    <h3 className="text-lg font-semibold text-gray-900 mb-4">Equity Curve</h3>
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="timestamp"
+          tickFormatter={(ts) => new Date(ts).toLocaleDateString()}
+        />
+        <YAxis />
+        <Tooltip labelFormatter={(ts) => new Date(ts).toLocaleString()} />
+        <Line type="monotone" dataKey="equity" stroke="#4f46e5" strokeWidth={2} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  </div>
+);
+
+export default EquityCurveChart;

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircle, XCircle, ArrowUp, ArrowDown, PieChart, Target, Briefcase,
   Clock, Shield, Zap
 } from 'lucide-react';
+import EquityCurveChart, { EquityPoint } from '../components/EquityCurveChart';
 
 // Tipos TypeScript
 interface Account {
@@ -144,6 +145,12 @@ const api = {
     const data = await response.json();
     console.log('✅ Positions data received:', data);
     return data;
+  },
+
+  async getEquityCurve(): Promise<EquityPoint[]> {
+    const response = await authenticatedFetch(`${this.baseUrl}/trades/equity-curve`);
+    const data = await response.json();
+    return Array.isArray(data) ? data : [];
   }
 };
 
@@ -337,6 +344,7 @@ const TradingDashboard: React.FC = () => {
   const [signals, setSignals] = useState<Signal[]>([]);
   const [orders, setOrders] = useState<Order[]>([]);
   const [portfolio, setPortfolio] = useState<PortfolioData | null>(null);
+  const [equityCurve, setEquityCurve] = useState<EquityPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
@@ -351,11 +359,12 @@ const TradingDashboard: React.FC = () => {
         throw new Error('No authentication token found. Please log in again.');
       }
 
-      const [accountData, signalsData, ordersData, portfolioData] = await Promise.all([
+      const [accountData, signalsData, ordersData, portfolioData, equityData] = await Promise.all([
         api.getAccount(),
         api.getSignals(),
         api.getOrders(),
-        api.getPositions()
+        api.getPositions(),
+        api.getEquityCurve()
       ]);
 
       console.log('✅ All data fetched successfully');
@@ -364,6 +373,7 @@ const TradingDashboard: React.FC = () => {
       setSignals(signalsData);
       setOrders(ordersData);
       setPortfolio(portfolioData);
+      setEquityCurve(equityData);
       setError(null);
       setLastUpdate(new Date());
     } catch (err: any) {
@@ -526,6 +536,11 @@ const TradingDashboard: React.FC = () => {
             )}
           </div>
         </div>
+      </div>
+
+      {/* Equity Curve */}
+      <div className="mb-8">
+        <EquityCurveChart data={equityCurve} />
       </div>
 
       {/* System Status */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -87,6 +87,10 @@ export const api = {
       return authenticatedFetch(`${API_BASE_URL}/trades`);
     },
 
+    getEquityCurve: async () => {
+      return authenticatedFetch(`${API_BASE_URL}/trades/equity-curve`);
+    },
+
     getPositions: async () => {
       return authenticatedFetch(`${API_BASE_URL}/positions`);
     },


### PR DESCRIPTION
## Summary
- expose `/trades/equity-curve` endpoint
- return cumulative equity points from `TradeService`
- define `EquityPointSchema`
- add front-end API call and React chart component
- show equity curve on dashboard

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: TypeScript errors due to missing dependencies)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6867f62a78c48331ab71e7b3e4506f5d