### PR TITLE
Fix dashboard type import

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -4,7 +4,8 @@ import {
   CheckCircle, XCircle, ArrowUp, ArrowDown, PieChart, Target, Briefcase,
   Clock, Shield, Zap
 } from 'lucide-react';
-import EquityCurveChart, { EquityPoint } from '../components/EquityCurveChart';
+import EquityCurveChart from '../components/EquityCurveChart';
+import type { EquityPoint } from '../components/EquityCurveChart';
 
 // Tipos TypeScript
 interface Account {


### PR DESCRIPTION
## Summary
- update Dashboard to use type-only import for `EquityPoint`

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*
- `npm run build` *(fails: multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867f91346908331ab80863494ebfe5b