### PR TITLE
Add Strategy model

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -26,6 +26,7 @@ from app.models.signal import Signal  # noqa: F401
 from app.models.strategy_position import StrategyPosition  # noqa: F401
 from app.models.user import User  # noqa: F401
 from app.models.trades import Trade  # noqa: F401
+from app.models.strategy import Strategy  # noqa: F401
 
 # Configurar la URL de la base de datos desde settings
 config.set_main_option('sqlalchemy.url', settings.database_url)

--- a/alembic/versions/50ec6c6fbe36_create_strategies_table.py
+++ b/alembic/versions/50ec6c6fbe36_create_strategies_table.py
@@ -1,0 +1,41 @@
+"""create strategies table
+
+Revision ID: 50ec6c6fbe36
+Revises: 2f1f8a38381d
+Create Date: 2025-07-04 16:29:26.226363
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '50ec6c6fbe36'
+down_revision: Union[str, Sequence[str], None] = '2f1f8a38381d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "strategies",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=True),
+        sa.PrimaryKeyConstraint("id")
+    )
+    op.create_index(op.f("ix_strategies_id"), "strategies", ["id"], unique=False)
+    op.create_index(op.f("ix_strategies_name"), "strategies", ["name"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_strategies_name"), table_name="strategies")
+    op.drop_index(op.f("ix_strategies_id"), table_name="strategies")
+    op.drop_table("strategies")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 from .user import User
 from .signal import Signal
 from .strategy_position import StrategyPosition
+from .strategy import Strategy
 
-__all__ = ["User", "Signal", "StrategyPosition"]
+__all__ = ["User", "Signal", "StrategyPosition", "Strategy"]

--- a/app/models/strategy.py
+++ b/app/models/strategy.py
@@ -1,0 +1,24 @@
+# backend/app/models/strategy.py
+
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+
+class Strategy(Base):
+    __tablename__ = "strategies"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, index=True)
+    description = Column(Text, nullable=True)
+
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    user = relationship("User")
+
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<Strategy({self.name})>"


### PR DESCRIPTION
## Summary
- create `Strategy` SQLAlchemy model with optional user owner
- export `Strategy` in models package and ensure Alembic imports it
- add Alembic migration for new `strategies` table

## Testing
- `pip install sqlalchemy alembic`
- `pip install pydantic==2.5.0 pydantic-settings==2.1.0 python-dotenv`
- `pip install werkzeug`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868007a58888331aec1be5de10ccb38