### PR TITLE
Add strategy schemas and CRUD API

### DIFF
--- a/app/api/v1/strategies.py
+++ b/app/api/v1/strategies.py
@@ -1,0 +1,77 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from ..database import get_db
+from ..models.strategy import Strategy
+from ..models.user import User
+from ..schemas.strategy import StrategyCreate, StrategyUpdate, StrategyOut
+from ..core.auth import get_current_verified_user
+
+router = APIRouter()
+
+
+@router.get("/strategies", response_model=List[StrategyOut])
+async def list_strategies(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    return db.query(Strategy).order_by(Strategy.created_at.desc()).all()
+
+
+@router.post("/strategies", response_model=StrategyOut)
+async def create_strategy(
+    strategy_in: StrategyCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    strategy = Strategy(name=strategy_in.name, description=strategy_in.description)
+    db.add(strategy)
+    db.commit()
+    db.refresh(strategy)
+    return strategy
+
+
+@router.get("/strategies/{strategy_id}", response_model=StrategyOut)
+async def get_strategy(
+    strategy_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    strategy = db.query(Strategy).filter(Strategy.id == strategy_id).first()
+    if not strategy:
+        raise HTTPException(status_code=404, detail="Strategy not found")
+    return strategy
+
+
+@router.put("/strategies/{strategy_id}", response_model=StrategyOut)
+async def update_strategy(
+    strategy_id: int,
+    strategy_in: StrategyUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    strategy = db.query(Strategy).filter(Strategy.id == strategy_id).first()
+    if not strategy:
+        raise HTTPException(status_code=404, detail="Strategy not found")
+    if strategy_in.name is not None:
+        strategy.name = strategy_in.name
+    if strategy_in.description is not None:
+        strategy.description = strategy_in.description
+    db.commit()
+    db.refresh(strategy)
+    return strategy
+
+
+@router.delete("/strategies/{strategy_id}")
+async def delete_strategy(
+    strategy_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    strategy = db.query(Strategy).filter(Strategy.id == strategy_id).first()
+    if not strategy:
+        raise HTTPException(status_code=404, detail="Strategy not found")
+    db.delete(strategy)
+    db.commit()
+    return {"detail": "Strategy deleted"}

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from .api.v1.webhooks import router as webhooks_router
 from .api.v1.orders import router as orders_router
 from .api.v1.auth import router as auth_router
 from .api.v1.trades import router as trades_router
+from .api.v1.strategies import router as strategies_router
 
 app = FastAPI(
     title=settings.app_name,
@@ -24,6 +25,7 @@ app.add_middleware(
 app.include_router(webhooks_router, prefix="/api/v1", tags=["webhooks"])
 app.include_router(orders_router, prefix="/api/v1", tags=["orders"])
 app.include_router(trades_router, prefix="/api/v1", tags=["trades"])
+app.include_router(strategies_router, prefix="/api/v1", tags=["strategies"])
 app.include_router(auth_router, prefix="/api/v1/auth", tags=["authentication"])
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 from .user import User
 from .signal import Signal
 from .strategy_position import StrategyPosition
+from .strategy import Strategy
 
-__all__ = ["User", "Signal", "StrategyPosition"]
+__all__ = ["User", "Signal", "StrategyPosition", "Strategy"]

--- a/app/models/strategy.py
+++ b/app/models/strategy.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.sql import func
+from ..database import Base
+
+
+class Strategy(Base):
+    __tablename__ = "strategies"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True, nullable=False, index=True)
+    description = Column(String(255), nullable=True)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<Strategy({self.id}, {self.name})>"

--- a/app/schemas/strategy.py
+++ b/app/schemas/strategy.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+
+
+class StrategyBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+
+
+class StrategyCreate(StrategyBase):
+    pass
+
+
+class StrategyUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class StrategyOut(StrategyBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- add SQLAlchemy model for strategies
- define Strategy Pydantic models
- create CRUD router for strategies
- register strategies routes in main app

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68680120077c8331912fb6f1686d9431