### PR TITLE
Add strategy metrics service and API

### DIFF
--- a/app/api/v1/strategies.py
+++ b/app/api/v1/strategies.py
@@ -1,0 +1,28 @@
+# backend/app/api/v1/strategies.py
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...models.user import User
+from ...services.trade_service import TradeService
+from ...core.auth import get_current_verified_user
+
+router = APIRouter()
+
+
+@router.get("/strategies/{strategy_id}/metrics")
+async def get_strategy_metrics(
+    strategy_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user)
+):
+    """Return trading metrics for a given strategy."""
+    service = TradeService(db)
+    return {
+        "strategy_id": strategy_id,
+        "total_pl": service.calculate_total_pl(strategy_id),
+        "win_rate": service.calculate_win_rate(strategy_id),
+        "profit_factor": service.calculate_profit_factor(strategy_id),
+        "drawdown": service.calculate_drawdown(strategy_id),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from .api.v1.webhooks import router as webhooks_router
 from .api.v1.orders import router as orders_router
 from .api.v1.auth import router as auth_router
 from .api.v1.trades import router as trades_router
+from .api.v1.strategies import router as strategies_router
 
 app = FastAPI(
     title=settings.app_name,
@@ -25,6 +26,7 @@ app.include_router(webhooks_router, prefix="/api/v1", tags=["webhooks"])
 app.include_router(orders_router, prefix="/api/v1", tags=["orders"])
 app.include_router(trades_router, prefix="/api/v1", tags=["trades"])
 app.include_router(auth_router, prefix="/api/v1/auth", tags=["authentication"])
+app.include_router(strategies_router, prefix="/api/v1", tags=["strategies"])
 
 @app.get("/")
 async def root():

--- a/app/services/trade_service.py
+++ b/app/services/trade_service.py
@@ -62,3 +62,53 @@ class TradeService:
             timestamp = trade.closed_at or trade.opened_at
             equity_curve.append({"timestamp": timestamp, "equity": cumulative})
         return equity_curve
+
+    # New metrics calculation methods
+
+    def _get_strategy_trades(self, strategy_id: str):
+        """Return closed trades for a given strategy ordered by close time."""
+        return (
+            self.db.query(Trade)
+            .filter(Trade.strategy_id == strategy_id)
+            .filter(Trade.status == "closed")
+            .order_by(Trade.closed_at)
+            .all()
+        )
+
+    def calculate_total_pl(self, strategy_id: str) -> float:
+        """Total profit or loss for the strategy."""
+        trades = self._get_strategy_trades(strategy_id)
+        return sum((t.pnl or 0.0) for t in trades)
+
+    def calculate_win_rate(self, strategy_id: str) -> float:
+        """Fraction of winning trades (0-1 scale)."""
+        trades = self._get_strategy_trades(strategy_id)
+        total = len(trades)
+        if total == 0:
+            return 0.0
+        wins = sum(1 for t in trades if (t.pnl or 0.0) > 0)
+        return wins / total
+
+    def calculate_profit_factor(self, strategy_id: str) -> float:
+        """Ratio of gross profit to gross loss."""
+        trades = self._get_strategy_trades(strategy_id)
+        total_profit = sum((t.pnl or 0.0) for t in trades if (t.pnl or 0.0) > 0)
+        total_loss = sum(-(t.pnl or 0.0) for t in trades if (t.pnl or 0.0) < 0)
+        if total_loss == 0:
+            return 0.0
+        return total_profit / total_loss
+
+    def calculate_drawdown(self, strategy_id: str) -> float:
+        """Maximum drawdown of the strategy's equity curve."""
+        trades = self._get_strategy_trades(strategy_id)
+        cumulative = 0.0
+        peak = 0.0
+        max_dd = 0.0
+        for trade in trades:
+            cumulative += trade.pnl or 0.0
+            if cumulative > peak:
+                peak = cumulative
+            drawdown = peak - cumulative
+            if drawdown > max_dd:
+                max_dd = drawdown
+        return -max_dd


### PR DESCRIPTION
## Summary
- compute strategy performance metrics in `TradeService`
- expose `/strategies/{strategy_id}/metrics` API endpoint
- wire up strategies router in the main app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686801207f448331aee204002468a148