### PR TITLE
Fix strategies API endpoint

### DIFF
--- a/app/api/v1/strategies.py
+++ b/app/api/v1/strategies.py
@@ -1,15 +1,76 @@
 
 # backend/app/api/v1/strategies.py
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
+from typing import List
 
 from ...database import get_db
 from ...models.user import User
+from ...models.strategy import Strategy
 from ...services.trade_service import TradeService
 from ...core.auth import get_current_verified_user
+from ...schemas.strategy import StrategyCreate, StrategyUpdate, StrategyOut
 
 router = APIRouter()
+
+@router.get("/strategies", response_model=List[StrategyOut])
+async def list_strategies(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Return all strategies."""
+    return db.query(Strategy).all()
+
+
+@router.post("/strategies", response_model=StrategyOut, status_code=status.HTTP_201_CREATED)
+async def create_strategy(
+    strategy: StrategyCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Create a new strategy."""
+    new_strategy = Strategy(**strategy.model_dump())
+    db.add(new_strategy)
+    db.commit()
+    db.refresh(new_strategy)
+    return new_strategy
+
+
+@router.put("/strategies/{strategy_id}", response_model=StrategyOut)
+async def update_strategy(
+    strategy_id: int,
+    updates: StrategyUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Update an existing strategy."""
+    strategy = db.query(Strategy).filter(Strategy.id == strategy_id).first()
+    if not strategy:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found")
+
+    update_data = updates.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(strategy, field, value)
+
+    db.commit()
+    db.refresh(strategy)
+    return strategy
+
+
+@router.delete("/strategies/{strategy_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_strategy(
+    strategy_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Delete a strategy."""
+    strategy = db.query(Strategy).filter(Strategy.id == strategy_id).first()
+    if not strategy:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found")
+    db.delete(strategy)
+    db.commit()
+    return None
 
 @router.get("/strategies/{strategy_id}/metrics")
 async def get_strategy_metrics(

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,6 @@ app.include_router(orders_router, prefix="/api/v1", tags=["orders"])
 app.include_router(trades_router, prefix="/api/v1", tags=["trades"])
 app.include_router(strategies_router, prefix="/api/v1", tags=["strategies"])
 app.include_router(auth_router, prefix="/api/v1/auth", tags=["authentication"])
-app.include_router(strategies_router, prefix="/api/v1", tags=["strategies"])
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
## Summary
- remove duplicate strategies router registration
- add CRUD endpoints for strategies

## Testing
- `python -m py_compile app/api/v1/strategies.py app/main.py`
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680d6206208331805bea434a1e5f2c