### PR TITLE
Implement strategy metrics modal

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -128,6 +128,10 @@ export const api = {
         method: 'DELETE',
       });
     },
+
+    metrics: async (id: number) => {
+      return authenticatedFetch(`${API_BASE_URL}/strategies/${id}/metrics`);
+    },
   },
 
   // Admin endpoints (if user is admin)


### PR DESCRIPTION
## Summary
- expose strategy metrics API on the frontend service
- display metrics (drawdown, profit factor, etc.) in Strategies page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS7026 JSX element implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868250b54448331b8651a509dba4748