### PR TITLE
Add websocket account update stream

### DIFF
--- a/app/integrations/alpaca/stream.py
+++ b/app/integrations/alpaca/stream.py
@@ -3,6 +3,7 @@ import json
 
 try:  # alpaca-py may not be installed during testing
     from alpaca.data.live import StockDataStream, CryptoDataStream
+    from alpaca.trading.stream import TradingStream
 except Exception:  # pragma: no cover - fallback for tests
     class _Dummy:
         def __init__(self, *_, **__):
@@ -16,8 +17,14 @@ except Exception:  # pragma: no cover - fallback for tests
 
     StockDataStream = CryptoDataStream = _Dummy
 
+    class TradingStream(_Dummy):
+        def subscribe_trade_updates(self, *_, **__):
+            pass
+
 from ...config import settings
 from ...websockets import ws_manager
+from .client import alpaca_client
+from ...services.position_manager import position_manager
 
 
 class AlpacaStream:
@@ -30,8 +37,17 @@ class AlpacaStream:
         self.crypto_stream = CryptoDataStream(
             settings.alpaca_api_key, settings.alpaca_secret_key
         )
+        self.trading_stream = TradingStream(
+            settings.alpaca_api_key,
+            settings.alpaca_secret_key,
+            paper=True,
+        )
+        self.trading_stream.subscribe_trade_updates(self._handle_trade_update)
+        if hasattr(self.trading_stream, "subscribe_account_updates"):
+            self.trading_stream.subscribe_account_updates(self._handle_trade_update)
         self._stock_task: asyncio.Task | None = None
         self._crypto_task: asyncio.Task | None = None
+        self._trading_task: asyncio.Task | None = None
 
     async def _handle_trade(self, trade) -> None:
         """Broadcast trade updates to all websocket clients."""
@@ -39,12 +55,30 @@ class AlpacaStream:
             json.dumps({"event": "quote_update", "payload": trade.__dict__})
         )
 
+    async def _handle_trade_update(self, update) -> None:
+        """Handle account or trade updates from TradingStream."""
+        await self._broadcast_account_update()
+
+    async def _broadcast_account_update(self) -> None:
+        """Fetch account metrics and broadcast them."""
+        account = alpaca_client.get_account()
+        summary = position_manager.get_portfolio_summary()
+        payload = {
+            "portfolio_value": float(getattr(account, "portfolio_value", 0)),
+            "cash": float(getattr(account, "cash", 0)),
+            "buying_power": float(getattr(account, "buying_power", 0)),
+            "total_positions": summary.get("total_positions", 0),
+        }
+        await ws_manager.broadcast(json.dumps({"event": "account_update", "payload": payload}))
+
     def _ensure_tasks(self) -> None:
         loop = asyncio.get_running_loop()
         if self._stock_task is None:
             self._stock_task = loop.create_task(self.stock_stream._run_forever())
         if self._crypto_task is None:
             self._crypto_task = loop.create_task(self.crypto_stream._run_forever())
+        if self._trading_task is None:
+            self._trading_task = loop.create_task(self.trading_stream._run_forever())
 
     def start(self) -> None:
         """Start background tasks without subscribing to any symbol."""

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -392,6 +392,22 @@ const TradingDashboard: React.FC = () => {
       onSignal: (sig) => setSignals((prev) => [sig, ...prev]),
       onOrder: (order) => setOrders((prev) => [order, ...prev]),
       onTrade: () => fetchAllData(),
+      onAccountUpdate: (data) => {
+        setAccount((prev) => prev ? { ...prev, ...data } : data);
+        setPortfolio((prev) =>
+          prev
+            ? {
+                ...prev,
+                cash: data.cash,
+                buying_power: data.buying_power,
+                portfolio_value: data.portfolio_value,
+                total_positions: data.total_positions,
+                remaining_slots: Math.max(0, prev.max_positions - data.total_positions)
+              }
+            : prev
+        );
+        setLastUpdate(new Date());
+      },
     });
     return () => ws.close();
   }, []);

--- a/frontend/src/services/ws.ts
+++ b/frontend/src/services/ws.ts
@@ -2,6 +2,7 @@ export interface WSHandlers {
   onSignal?: (data: any) => void;
   onOrder?: (data: any) => void;
   onTrade?: (data: any) => void;
+  onAccountUpdate?: (data: any) => void;
 }
 
 export const connectWebSocket = (handlers: WSHandlers) => {
@@ -18,6 +19,9 @@ export const connectWebSocket = (handlers: WSHandlers) => {
           break;
         case 'trade_update':
           handlers.onTrade?.(msg.payload);
+          break;
+        case 'account_update':
+          handlers.onAccountUpdate?.(msg.payload);
           break;
         default:
           break;

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,7 +1,12 @@
 import math
 from datetime import datetime
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault('ALPACA_API_KEY', 'key')
+os.environ.setdefault('ALPACA_SECRET_KEY', 'secret')
+os.environ.setdefault('SECRET_KEY', 'secret')
 
 from app.database import Base
 from app.models.trades import Trade

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,71 @@
+import asyncio
+import json
+import sys
+import types
+import os
+
+# Stub alpaca modules for testing
+sys.modules.setdefault('alpaca', types.ModuleType('alpaca'))
+sys.modules.setdefault('alpaca.trading', types.ModuleType('alpaca.trading'))
+sys.modules.setdefault('alpaca.trading.client', types.ModuleType('alpaca.trading.client'))
+sys.modules.setdefault('alpaca.trading.requests', types.ModuleType('alpaca.trading.requests'))
+sys.modules.setdefault('alpaca.trading.enums', types.ModuleType('alpaca.trading.enums'))
+sys.modules.setdefault('alpaca.trading.stream', types.ModuleType('alpaca.trading.stream'))
+sys.modules.setdefault('alpaca.data', types.ModuleType('alpaca.data'))
+sys.modules.setdefault('alpaca.data.live', types.ModuleType('alpaca.data.live'))
+sys.modules.setdefault('alpaca.data.historical', types.ModuleType('alpaca.data.historical'))
+sys.modules.setdefault('alpaca.data.requests', types.ModuleType('alpaca.data.requests'))
+
+os.environ.setdefault('ALPACA_API_KEY', 'key')
+os.environ.setdefault('ALPACA_SECRET_KEY', 'secret')
+os.environ.setdefault('SECRET_KEY', 'secret')
+
+class DummyStream:
+    def __init__(self, *a, **kw):
+        self.handler = None
+    def subscribe_trade_updates(self, handler):
+        self.handler = handler
+    async def _run_forever(self):
+        await asyncio.sleep(0)
+
+class DummyDataStream:
+    def __init__(self, *a, **kw):
+        pass
+    def subscribe_trades(self, *a, **kw):
+        pass
+    async def _run_forever(self):
+        await asyncio.sleep(0)
+
+sys.modules['alpaca.trading.stream'].TradingStream = DummyStream
+sys.modules['alpaca.data.live'].StockDataStream = DummyDataStream
+sys.modules['alpaca.data.live'].CryptoDataStream = DummyDataStream
+sys.modules['alpaca.data.historical'].CryptoHistoricalDataClient = DummyDataStream
+sys.modules['alpaca.data.historical'].StockHistoricalDataClient = DummyDataStream
+sys.modules['alpaca.data.requests'].CryptoLatestQuoteRequest = lambda *a, **k: None
+sys.modules['alpaca.data.requests'].StockLatestQuoteRequest = lambda *a, **k: None
+sys.modules['alpaca.trading.client'].TradingClient = lambda *a, **k: None
+sys.modules['alpaca.trading.requests'].MarketOrderRequest = lambda *a, **k: None
+sys.modules['alpaca.trading.requests'].GetOrdersRequest = lambda *a, **k: None
+sys.modules['alpaca.trading.enums'].OrderSide = types.SimpleNamespace(BUY=1, SELL=2)
+sys.modules['alpaca.trading.enums'].TimeInForce = types.SimpleNamespace(DAY=1, GTC=2)
+sys.modules['alpaca.trading.enums'].AssetClass = types.SimpleNamespace(CRYPTO=1, US_EQUITY=2)
+
+from app.integrations.alpaca import stream as stream_module
+from app.websockets import ws_manager
+
+class DummyAccount:
+    cash = 100.0
+    portfolio_value = 200.0
+    buying_power = 150.0
+
+def test_trade_update_triggers_broadcast(monkeypatch):
+    messages = []
+    async def fake_broadcast(msg: str):
+        messages.append(json.loads(msg))
+    monkeypatch.setattr(ws_manager, 'broadcast', fake_broadcast)
+    monkeypatch.setattr(stream_module.alpaca_client, 'get_account', lambda: DummyAccount())
+    monkeypatch.setattr(stream_module.position_manager, 'get_portfolio_summary', lambda: {'total_positions': 1})
+    alpaca_stream = stream_module.AlpacaStream()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(alpaca_stream._handle_trade_update({}))
+    assert messages and messages[0]['event'] == 'account_update'

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import sys
 import types
+import os
 from fastapi.testclient import TestClient
 
 # Stub alpaca modules for testing without the actual package
@@ -13,6 +14,10 @@ sys.modules.setdefault('alpaca.trading.enums', types.ModuleType('alpaca.trading.
 sys.modules.setdefault('alpaca.data', types.ModuleType('alpaca.data'))
 sys.modules.setdefault('alpaca.data.historical', types.ModuleType('alpaca.data.historical'))
 sys.modules.setdefault('alpaca.data.requests', types.ModuleType('alpaca.data.requests'))
+
+os.environ.setdefault('ALPACA_API_KEY', 'key')
+os.environ.setdefault('ALPACA_SECRET_KEY', 'secret')
+os.environ.setdefault('SECRET_KEY', 'secret')
 
 # Provide dummy classes used during import
 class Dummy:


### PR DESCRIPTION
## Summary
- extend AlpacaStream with TradingStream and send `account_update` events
- support `account_update` in frontend websocket helpers and dashboard
- unit test trade update account broadcast

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868414f476c83319c2f57419adb8c62