### PR TITLE
Add simple pagination to trading pages

### DIFF
--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+interface PaginationProps {
+  currentPage: number;
+  totalItems: number;
+  pageSize?: number;
+  onPageChange: (page: number) => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({ currentPage, totalItems, pageSize = 10, onPageChange }) => {
+  const totalPages = Math.ceil(totalItems / pageSize);
+  if (totalPages <= 1) return null;
+
+  const handlePrev = () => {
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentPage < totalPages) {
+      onPageChange(currentPage + 1);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center mt-4 space-x-2">
+      <button
+        onClick={handlePrev}
+        disabled={currentPage === 1}
+        className="px-3 py-1 border rounded-md text-sm bg-white disabled:opacity-50"
+      >
+        Prev
+      </button>
+      <span className="text-sm">
+        Page {currentPage} of {totalPages}
+      </span>
+      <button
+        onClick={handleNext}
+        disabled={currentPage === totalPages}
+        className="px-3 py-1 border rounded-md text-sm bg-white disabled:opacity-50"
+      >
+        Next
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/pages/orders.tsx
+++ b/frontend/src/pages/orders.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUp, ArrowDown, Eye, MoreHorizontal, Target, Zap, PieChart,
   PlayCircle, Settings2
 } from 'lucide-react';
+import Pagination from '../components/Pagination';
 
 interface Order {
   id: string;
@@ -30,6 +31,12 @@ const OrdersPage: React.FC = () => {
   const [sortBy, setSortBy] = useState<'submitted_at' | 'filled_at' | 'symbol' | 'qty'>('submitted_at');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [selectedTimeRange, setSelectedTimeRange] = useState<'today' | 'week' | 'month' | 'all'>('all');
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 10;
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filter, searchTerm, sortBy, sortOrder, selectedTimeRange]);
 
   // Función para obtener el token del localStorage
   const getAuthToken = (): string | null => {
@@ -411,6 +418,19 @@ const OrdersPage: React.FC = () => {
       return 0;
     });
 
+  const totalPages = Math.ceil(filteredAndSortedOrders.length / PAGE_SIZE);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages || 1);
+    }
+  }, [totalPages, currentPage]);
+
+  const paginatedOrders = filteredAndSortedOrders.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
   const stats = {
     total: safeOrders.length,
     filled: safeOrders.filter(o => o.status.toLowerCase() === 'filled').length,
@@ -691,13 +711,19 @@ const OrdersPage: React.FC = () => {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {filteredAndSortedOrders.map((order) => (
+                {paginatedOrders.map((order) => (
                   <OrderRow key={order.id} order={order} />
                 ))}
               </tbody>
             </table>
           )}
         </div>
+        <Pagination
+          currentPage={currentPage}
+          totalItems={filteredAndSortedOrders.length}
+          pageSize={PAGE_SIZE}
+          onPageChange={setCurrentPage}
+        />
       </div>
 
       {/* Summary Section */}

--- a/frontend/src/pages/signals.tsx
+++ b/frontend/src/pages/signals.tsx
@@ -5,6 +5,7 @@ import {
   Search, TrendingUp, TrendingDown, Zap, BarChart3, Target,
   ArrowUp, ArrowDown, Calendar, Eye, Settings2
 } from 'lucide-react';
+import Pagination from '../components/Pagination';
 
 interface Signal {
   id: number;
@@ -28,6 +29,12 @@ const SignalsPage: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState<'timestamp' | 'confidence' | 'symbol'>('timestamp');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 10;
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filter, searchTerm, sortBy, sortOrder]);
 
   // Función para obtener el token del localStorage
   const getAuthToken = (): string | null => {
@@ -327,6 +334,19 @@ const SignalsPage: React.FC = () => {
       return 0;
     });
 
+  const totalPages = Math.ceil(filteredAndSortedSignals.length / PAGE_SIZE);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages || 1);
+    }
+  }, [totalPages, currentPage]);
+
+  const paginatedSignals = filteredAndSortedSignals.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
   const stats = {
     total: safeSignals.length,
     processed: safeSignals.filter(s => s.status === 'processed').length,
@@ -551,13 +571,19 @@ const SignalsPage: React.FC = () => {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {filteredAndSortedSignals.map((signal) => (
+                {paginatedSignals.map((signal) => (
                   <SignalRow key={signal.id} signal={signal} />
                 ))}
               </tbody>
             </table>
           )}
         </div>
+        <Pagination
+          currentPage={currentPage}
+          totalItems={filteredAndSortedSignals.length}
+          pageSize={PAGE_SIZE}
+          onPageChange={setCurrentPage}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/trades.tsx
+++ b/frontend/src/pages/trades.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import api from '../services/api';
+import Pagination from '../components/Pagination';
 
 interface Trade {
   id: number;
@@ -18,6 +19,8 @@ interface Trade {
 const TradesPage: React.FC = () => {
   const [trades, setTrades] = useState<Trade[]>([]);
   const [loading, setLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 10;
 
   useEffect(() => {
     const fetchTrades = async () => {
@@ -39,6 +42,23 @@ const TradesPage: React.FC = () => {
     const interval = window.setInterval(fetchTrades, 30000);
     return () => clearInterval(interval);
   }, []);
+
+  const totalPages = Math.ceil(trades.length / PAGE_SIZE);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages || 1);
+    }
+  }, [totalPages, currentPage]);
+
+  const paginatedTrades = trades.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [trades]);
 
   return (
     <div className="p-8 bg-gray-50 min-h-screen max-w-7xl mx-auto">
@@ -66,7 +86,7 @@ const TradesPage: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {trades.map((trade) => (
+              {paginatedTrades.map((trade) => (
                 <tr key={trade.id} className="border-b hover:bg-gray-50">
                   <td className="px-4 py-2">{trade.strategy_id}</td>
                   <td className="px-4 py-2">{trade.symbol}</td>
@@ -89,6 +109,12 @@ const TradesPage: React.FC = () => {
             </tbody>
           </table>
         </div>
+        <Pagination
+          currentPage={currentPage}
+          totalItems={trades.length}
+          pageSize={PAGE_SIZE}
+          onPageChange={setCurrentPage}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- create a reusable `Pagination` component
- paginate Signals, Orders and Trades pages

## Testing
- `npm test` *(fails: missing script)*
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`, `app`, and `fastapi`)*

------
https://chatgpt.com/codex/tasks/task_e_68684aaa31e08331bbcac79652b5e070