### PR TITLE
Enable portfolio-based Alpaca config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# EllenTradingBot v2
+
+This repository contains a trading bot built with FastAPI and Alpaca. 
+
+## Configuration
+
+The application reads its configuration from environment variables or a `.env` file. The Alpaca credentials can be configured per portfolio. Use the variable `ALPACA_PORTFOLIO` to select which portfolio is active. For each portfolio provide the following variables:
+
+```
+ALPACA_<PORTFOLIO>_API_KEY
+ALPACA_<PORTFOLIO>_SECRET_KEY
+ALPACA_<PORTFOLIO>_BASE_URL  # optional, defaults to paper trading URL
+```
+
+If `ALPACA_PORTFOLIO` is not set, the prefix `DEFAULT` is used. The settings also fall back to `ALPACA_API_KEY`, `ALPACA_SECRET_KEY` and `ALPACA_BASE_URL` for compatibility.
+
+After modifying environment variables, restart the application so the new credentials are loaded.

--- a/app/config.py
+++ b/app/config.py
@@ -15,8 +15,9 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379"
 
     # Alpaca
-    alpaca_api_key: str
-    alpaca_secret_key: str
+    alpaca_portfolio: str = "DEFAULT"
+    alpaca_api_key: Optional[str] = None
+    alpaca_secret_key: Optional[str] = None
     alpaca_base_url: str = "https://paper-api.alpaca.markets/v2"
 
     # App
@@ -39,6 +40,22 @@ class Settings(BaseSettings):
     smtp_username: Optional[str] = None
     smtp_password: Optional[str] = None
     from_email: Optional[str] = None
+
+    def __init__(self, **values):
+        super().__init__(**values)
+        prefix = self.alpaca_portfolio.upper() if self.alpaca_portfolio else "DEFAULT"
+        self.alpaca_api_key = os.getenv(
+            f"ALPACA_{prefix}_API_KEY",
+            os.getenv("ALPACA_API_KEY", self.alpaca_api_key),
+        )
+        self.alpaca_secret_key = os.getenv(
+            f"ALPACA_{prefix}_SECRET_KEY",
+            os.getenv("ALPACA_SECRET_KEY", self.alpaca_secret_key),
+        )
+        self.alpaca_base_url = os.getenv(
+            f"ALPACA_{prefix}_BASE_URL",
+            os.getenv("ALPACA_BASE_URL", self.alpaca_base_url),
+        )
 
     class Config:
         env_file = ".env"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -11,7 +11,6 @@ alembic==1.12.1
 redis==5.0.1
 
 # Alpaca trading
-alpaca-trade-api==3.1.1
 alpaca-py==0.18.0
 
 # Validación y configuración
@@ -23,13 +22,11 @@ python-dotenv==1.0.0
 python-multipart==0.0.6
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
-
-# WebSockets (compatible con alpaca-trade-api)
-websockets>=9.0,<11
+werkzeug==3.0.1
 
 # Testing
 pytest==7.4.3
 pytest-asyncio==0.21.1
 httpx==0.25.2
 
-pydantic[email]==2.2.0
+pydantic[email]==2.5.0


### PR DESCRIPTION
## Summary
- allow selecting Alpaca API keys by portfolio
- document portfolio configuration in README
- fix dependency conflicts in requirements

## Testing
- `pip install -r app/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686850b6d888833195dc8cd5bc3855d5