### PR TITLE
Fix down_revision in portfolio migration

### DIFF
--- a/alembic/versions/50c3e5bad110_add_portfolio_model.py
+++ b/alembic/versions/50c3e5bad110_add_portfolio_model.py
@@ -1,12 +1,16 @@
 """Add portfolio model"""
 
-revision = '50c3e5bad110'
-revises = 'f9db15bb6dbc'
-branch_labels = None
-depends_on = None
+from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '50c3e5bad110'
+down_revision: Union[str, Sequence[str], None] = 'f9db15bb6dbc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- fix missing `down_revision` in portfolio migration script

## Testing
- `pip install -r app/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685df82bb483318a07829926221409