### PR TITLE
Fix Alembic multi-head with merge revision

### DIFF
--- a/alembic/versions/2152693dfc7b_merge_heads.py
+++ b/alembic/versions/2152693dfc7b_merge_heads.py
@@ -1,0 +1,28 @@
+"""merge heads
+
+Revision ID: 2152693dfc7b
+Revises: 50c3e5bad110, 50ec6c6fbe36
+Create Date: 2025-07-05 00:04:32.498475
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2152693dfc7b'
+down_revision: Union[str, Sequence[str], None] = ('50c3e5bad110', '50ec6c6fbe36')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
- resolve multiple alembic heads by merging 50c3e5bad110 and 50ec6c6fbe36

## Testing
- `alembic heads`

------
https://chatgpt.com/codex/tasks/task_e_68686b9ac4208331964dfefa83483999