### PR TITLE
Enable user portfolios in frontend and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a trading bot built with FastAPI and Alpaca.
 
 ## Configuration
 
-Alpaca credentials are now stored securely in the database instead of environment
-variables.  You can create multiple portfolios and select the active one through
-the API or from the frontend settings page.  Existing environment variables are
-still used as a fallback when no portfolio is configured.
+Alpaca credentials are stored securely in the database. Each user can create
+their own portfolios from the frontend or via the API and select which one is
+active. The application no longer falls back to environment variables for
+credentials.

--- a/alembic/versions/cda90f233a37_add_user_id_to_portfolio.py
+++ b/alembic/versions/cda90f233a37_add_user_id_to_portfolio.py
@@ -1,0 +1,24 @@
+"""add user_id to portfolio
+
+Revision ID: cda90f233a37
+Revises: f9db15bb6dbc
+Create Date: 2025-07-02 00:00:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'cda90f233a37'
+down_revision: Union[str, Sequence[str], None] = 'f9db15bb6dbc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.add_column('portfolios', sa.Column('user_id', sa.Integer(), nullable=False, server_default='1'))
+    op.create_foreign_key(None, 'portfolios', 'users', ['user_id'], ['id'])
+    op.alter_column('portfolios', 'user_id', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_constraint(None, 'portfolios', type_='foreignkey')
+    op.drop_column('portfolios', 'user_id')

--- a/app/api/v1/portfolios.py
+++ b/app/api/v1/portfolios.py
@@ -9,8 +9,11 @@ router = APIRouter()
 
 
 @router.get("/portfolios")
-def list_portfolios(db: Session = Depends(get_db), current_user: User = Depends(get_current_verified_user)):
-    portfolios = portfolio_service.get_all(db)
+def list_portfolios(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    portfolios = portfolio_service.get_all(db, current_user)
     return [{"id": p.id, "name": p.name, "is_active": p.is_active} for p in portfolios]
 
 
@@ -23,15 +26,17 @@ def create_portfolio(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_verified_user),
 ):
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Not authorized")
-    portfolio = portfolio_service.create_portfolio(db, name, api_key, secret_key, base_url)
+    portfolio = portfolio_service.create_portfolio(
+        db, current_user, name, api_key, secret_key, base_url
+    )
     return {"id": portfolio.id, "name": portfolio.name}
 
 
 @router.post("/portfolios/{portfolio_id}/activate")
-def activate_portfolio(portfolio_id: int, db: Session = Depends(get_db), current_user: User = Depends(get_current_verified_user)):
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Not authorized")
-    portfolio_service.activate_portfolio(db, portfolio_id)
+def activate_portfolio(
+    portfolio_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    portfolio_service.activate_portfolio(db, current_user, portfolio_id)
     return {"status": "ok"}

--- a/app/config.py
+++ b/app/config.py
@@ -56,8 +56,12 @@ class Settings(BaseSettings):
                     hashlib.sha256(self.secret_key.encode()).digest()
                 )
                 f = Fernet(key)
-                self.alpaca_api_key = f.decrypt(portfolio.api_key_encrypted.encode()).decode()
-                self.alpaca_secret_key = f.decrypt(portfolio.secret_key_encrypted.encode()).decode()
+                self.alpaca_api_key = f.decrypt(
+                    portfolio.api_key_encrypted.encode()
+                ).decode()
+                self.alpaca_secret_key = f.decrypt(
+                    portfolio.secret_key_encrypted.encode()
+                ).decode()
             else:
                 self.alpaca_api_key = portfolio.api_key_encrypted
                 self.alpaca_secret_key = portfolio.secret_key_encrypted
@@ -65,24 +69,10 @@ class Settings(BaseSettings):
 
     def __init__(self, **values):
         super().__init__(**values)
-        prefix = self.alpaca_portfolio.upper() if self.alpaca_portfolio else "DEFAULT"
-        self.alpaca_api_key = os.getenv(
-            f"ALPACA_{prefix}_API_KEY",
-            os.getenv("ALPACA_API_KEY", self.alpaca_api_key),
-        )
-        self.alpaca_secret_key = os.getenv(
-            f"ALPACA_{prefix}_SECRET_KEY",
-            os.getenv("ALPACA_SECRET_KEY", self.alpaca_secret_key),
-        )
-        self.alpaca_base_url = os.getenv(
-            f"ALPACA_{prefix}_BASE_URL",
-            os.getenv("ALPACA_BASE_URL", self.alpaca_base_url),
-        )
 
     class Config:
         env_file = ".env"
-        env_file_encoding = 'utf-8'
+        env_file_encoding = "utf-8"
 
 
 settings = Settings()
-

--- a/app/models/portfolio.py
+++ b/app/models/portfolio.py
@@ -1,8 +1,10 @@
-from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
 from ..database import Base
 
+
 class Portfolio(Base):
-    __tablename__ = 'portfolios'
+    __tablename__ = "portfolios"
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(100), unique=True, nullable=False)
@@ -10,3 +12,6 @@ class Portfolio(Base):
     secret_key_encrypted = Column(String(255), nullable=False)
     base_url = Column(String(255), nullable=False)
     is_active = Column(Boolean, default=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    user = relationship("User", back_populates="portfolios")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -18,6 +18,7 @@ class User(Base):
     full_name = Column(String(255), nullable=True)
     signals = relationship("Signal", back_populates="user")
     trades = relationship("Trade", back_populates="user")
+    portfolios = relationship("Portfolio", back_populates="user")
 
     # Estados
     is_active = Column(Boolean, default=True)
@@ -54,4 +55,3 @@ class User(Base):
 
     def __repr__(self):
         return f"<User({self.username}, {self.email})>"
-

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,36 +1,71 @@
 // frontend/src/pages/Profile.tsx
 
-import React, { useState } from 'react';
-import { useAuth } from '../contexts/AuthContext';
+import React, { useState } from "react";
+import { useAuth } from "../contexts/AuthContext";
 import {
-  User, Mail, Calendar, Shield, CheckCircle, XCircle, Edit2, Save, X,
-  Key, Bell, Download, Upload, Settings, Eye, EyeOff, AlertTriangle,
-  Camera, MapPin, Phone, Globe, Briefcase, Award, Clock, Activity
-} from 'lucide-react';
+  User,
+  Mail,
+  Calendar,
+  Shield,
+  CheckCircle,
+  XCircle,
+  Edit2,
+  Save,
+  X,
+  Key,
+  Bell,
+  Download,
+  Upload,
+  Settings,
+  Eye,
+  EyeOff,
+  AlertTriangle,
+  Camera,
+  MapPin,
+  Phone,
+  Globe,
+  Briefcase,
+  Award,
+  Clock,
+  Activity,
+} from "lucide-react";
 
 const Profile: React.FC = () => {
   const { user, token, logout } = useAuth();
-  const [activeTab, setActiveTab] = useState<'profile' | 'security' | 'preferences' | 'activity'>('profile');
+  const [activeTab, setActiveTab] = useState<
+    "profile" | "security" | "preferences" | "activity"
+  >("profile");
   const [isEditing, setIsEditing] = useState(false);
   const [showPasswordChange, setShowPasswordChange] = useState(false);
   const [editForm, setEditForm] = useState({
-    full_name: user?.full_name || '',
-    email: user?.email || '',
+    full_name: user?.full_name || "",
+    email: user?.email || "",
   });
   const [passwordForm, setPasswordForm] = useState({
-    current_password: '',
-    new_password: '',
-    confirm_password: '',
+    current_password: "",
+    new_password: "",
+    confirm_password: "",
   });
   const [showPasswords, setShowPasswords] = useState({
     current: false,
     new: false,
     confirm: false,
   });
-  const [portfolios, setPortfolios] = useState<Array<{id:number;name:string;is_active:boolean}>>([]);
-  const [selectedPortfolio, setSelectedPortfolio] = useState<number | null>(null);
+  const [portfolios, setPortfolios] = useState<
+    Array<{ id: number; name: string; is_active: boolean }>
+  >([]);
+  const [selectedPortfolio, setSelectedPortfolio] = useState<number | null>(
+    null,
+  );
+  const [showPortfolioForm, setShowPortfolioForm] = useState(false);
+  const [newPortfolio, setNewPortfolio] = useState({
+    name: "",
+    api_key: "",
+    secret_key: "",
+    base_url: "",
+  });
 
-  const API_BASE_URL = 'http://localhost:8000/api/v1';
+  const API_BASE_URL = "http://localhost:8000/api/v1";
 
   React.useEffect(() => {
     const fetchPortfolios = async () => {
@@ -51,25 +86,45 @@ const Profile: React.FC = () => {
   const changePortfolio = async (id: number) => {
     setSelectedPortfolio(id);
     await fetch(`${API_BASE_URL}/portfolios/${id}/activate`, {
-      method: 'POST',
+      method: "POST",
       headers: { Authorization: `Bearer ${token}` },
     });
+  };
+
+  const createPortfolio = async () => {
+    const res = await fetch(`${API_BASE_URL}/portfolios`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(newPortfolio),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPortfolios([
+        ...portfolios,
+        { id: data.id, name: data.name, is_active: false },
+      ]);
+      setShowPortfolioForm(false);
+      setNewPortfolio({ name: "", api_key: "", secret_key: "", base_url: "" });
+    }
   };
 
   const handleSave = async () => {
     try {
       // TODO: Implementar actualización de perfil
-      console.log('Saving profile:', editForm);
+      console.log("Saving profile:", editForm);
       setIsEditing(false);
     } catch (error) {
-      console.error('Error updating profile:', error);
+      console.error("Error updating profile:", error);
     }
   };
 
   const handleCancel = () => {
     setEditForm({
-      full_name: user?.full_name || '',
-      email: user?.email || '',
+      full_name: user?.full_name || "",
+      email: user?.email || "",
     });
     setIsEditing(false);
   };
@@ -77,11 +132,15 @@ const Profile: React.FC = () => {
   const handlePasswordChange = async () => {
     try {
       // TODO: Implementar cambio de contraseña
-      console.log('Changing password');
+      console.log("Changing password");
       setShowPasswordChange(false);
-      setPasswordForm({ current_password: '', new_password: '', confirm_password: '' });
+      setPasswordForm({
+        current_password: "",
+        new_password: "",
+        confirm_password: "",
+      });
     } catch (error) {
-      console.error('Error changing password:', error);
+      console.error("Error changing password:", error);
     }
   };
 
@@ -98,8 +157,8 @@ const Profile: React.FC = () => {
       onClick={onClick}
       className={`flex items-center px-6 py-3 text-sm font-medium rounded-xl transition-all duration-200 ${
         active
-          ? 'bg-blue-100 text-blue-700 shadow-sm'
-          : 'text-gray-600 hover:bg-gray-100'
+          ? "bg-blue-100 text-blue-700 shadow-sm"
+          : "text-gray-600 hover:bg-gray-100"
       }`}
     >
       <Icon className="h-5 w-5 mr-2" />
@@ -183,11 +242,15 @@ const Profile: React.FC = () => {
             </button>
           </div>
           <div className="ml-6">
-            <h2 className="text-2xl font-bold text-gray-900">{user.username}</h2>
+            <h2 className="text-2xl font-bold text-gray-900">
+              {user.username}
+            </h2>
             <p className="text-gray-600">Professional Trader</p>
             <div className="flex items-center mt-2">
               <div className="w-2 h-2 bg-emerald-500 rounded-full mr-2"></div>
-              <span className="text-sm text-emerald-600 font-medium">Active Account</span>
+              <span className="text-sm text-emerald-600 font-medium">
+                Active Account
+              </span>
             </div>
           </div>
         </div>
@@ -202,13 +265,15 @@ const Profile: React.FC = () => {
               <input
                 type="text"
                 value={editForm.full_name}
-                onChange={(e) => setEditForm({ ...editForm, full_name: e.target.value })}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, full_name: e.target.value })
+                }
                 className="w-full p-4 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all duration-200"
                 placeholder="Enter your full name"
               />
             ) : (
               <div className="p-4 bg-gray-50 rounded-xl">
-                <p className="text-gray-900">{user.full_name || 'Not set'}</p>
+                <p className="text-gray-900">{user.full_name || "Not set"}</p>
               </div>
             )}
           </div>
@@ -221,7 +286,9 @@ const Profile: React.FC = () => {
               <input
                 type="email"
                 value={editForm.email}
-                onChange={(e) => setEditForm({ ...editForm, email: e.target.value })}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, email: e.target.value })
+                }
                 className="w-full p-4 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all duration-200"
               />
             ) : (
@@ -237,7 +304,9 @@ const Profile: React.FC = () => {
             </label>
             <div className="p-4 bg-gray-50 rounded-xl">
               <p className="text-gray-900">{user.username}</p>
-              <p className="text-xs text-gray-500 mt-1">Username cannot be changed</p>
+              <p className="text-xs text-gray-500 mt-1">
+                Username cannot be changed
+              </p>
             </div>
           </div>
 
@@ -246,7 +315,9 @@ const Profile: React.FC = () => {
               Member Since
             </label>
             <div className="p-4 bg-gray-50 rounded-xl">
-              <p className="text-gray-900">{new Date(user.created_at).toLocaleDateString()}</p>
+              <p className="text-gray-900">
+                {new Date(user.created_at).toLocaleDateString()}
+              </p>
             </div>
           </div>
         </div>
@@ -257,19 +328,27 @@ const Profile: React.FC = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <StatCard
             title="Account Status"
-            value={user.is_active ? 'Active' : 'Inactive'}
+            value={user.is_active ? "Active" : "Inactive"}
             icon={user.is_active ? CheckCircle : XCircle}
-            color={user.is_active ? 'bg-gradient-to-r from-emerald-500 to-green-500' : 'bg-gradient-to-r from-red-500 to-pink-500'}
+            color={
+              user.is_active
+                ? "bg-gradient-to-r from-emerald-500 to-green-500"
+                : "bg-gradient-to-r from-red-500 to-pink-500"
+            }
           />
           <StatCard
             title="Email Status"
-            value={user.is_verified ? 'Verified' : 'Unverified'}
+            value={user.is_verified ? "Verified" : "Unverified"}
             icon={user.is_verified ? Mail : AlertTriangle}
-            color={user.is_verified ? 'bg-gradient-to-r from-blue-500 to-indigo-500' : 'bg-gradient-to-r from-yellow-500 to-orange-500'}
+            color={
+              user.is_verified
+                ? "bg-gradient-to-r from-blue-500 to-indigo-500"
+                : "bg-gradient-to-r from-yellow-500 to-orange-500"
+            }
           />
           <StatCard
             title="Account Type"
-            value={user.is_admin ? 'Administrator' : 'Professional'}
+            value={user.is_admin ? "Administrator" : "Professional"}
             icon={user.is_admin ? Shield : Briefcase}
             color="bg-gradient-to-r from-purple-500 to-pink-500"
           />
@@ -315,7 +394,7 @@ const Profile: React.FC = () => {
             className="flex items-center px-4 py-2 text-blue-600 hover:bg-blue-50 rounded-xl transition-all duration-200"
           >
             <Key className="h-4 w-4 mr-2" />
-            {showPasswordChange ? 'Cancel' : 'Change Password'}
+            {showPasswordChange ? "Cancel" : "Change Password"}
           </button>
         }
       >
@@ -326,10 +405,14 @@ const Profile: React.FC = () => {
                 <Key className="h-5 w-5 text-gray-400 mr-3" />
                 <div>
                   <p className="font-medium text-gray-900">Password</p>
-                  <p className="text-sm text-gray-500">Last changed 30 days ago</p>
+                  <p className="text-sm text-gray-500">
+                    Last changed 30 days ago
+                  </p>
                 </div>
               </div>
-              <span className="text-emerald-600 text-sm font-medium">Strong</span>
+              <span className="text-emerald-600 text-sm font-medium">
+                Strong
+              </span>
             </div>
           </div>
         ) : (
@@ -340,18 +423,32 @@ const Profile: React.FC = () => {
               </label>
               <div className="relative">
                 <input
-                  type={showPasswords.current ? 'text' : 'password'}
+                  type={showPasswords.current ? "text" : "password"}
                   value={passwordForm.current_password}
-                  onChange={(e) => setPasswordForm({ ...passwordForm, current_password: e.target.value })}
+                  onChange={(e) =>
+                    setPasswordForm({
+                      ...passwordForm,
+                      current_password: e.target.value,
+                    })
+                  }
                   className="w-full p-4 pr-12 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
                   placeholder="Enter current password"
                 />
                 <button
                   type="button"
-                  onClick={() => setShowPasswords({ ...showPasswords, current: !showPasswords.current })}
+                  onClick={() =>
+                    setShowPasswords({
+                      ...showPasswords,
+                      current: !showPasswords.current,
+                    })
+                  }
                   className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
                 >
-                  {showPasswords.current ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                  {showPasswords.current ? (
+                    <EyeOff className="h-5 w-5" />
+                  ) : (
+                    <Eye className="h-5 w-5" />
+                  )}
                 </button>
               </div>
             </div>
@@ -362,18 +459,32 @@ const Profile: React.FC = () => {
               </label>
               <div className="relative">
                 <input
-                  type={showPasswords.new ? 'text' : 'password'}
+                  type={showPasswords.new ? "text" : "password"}
                   value={passwordForm.new_password}
-                  onChange={(e) => setPasswordForm({ ...passwordForm, new_password: e.target.value })}
+                  onChange={(e) =>
+                    setPasswordForm({
+                      ...passwordForm,
+                      new_password: e.target.value,
+                    })
+                  }
                   className="w-full p-4 pr-12 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
                   placeholder="Enter new password"
                 />
                 <button
                   type="button"
-                  onClick={() => setShowPasswords({ ...showPasswords, new: !showPasswords.new })}
+                  onClick={() =>
+                    setShowPasswords({
+                      ...showPasswords,
+                      new: !showPasswords.new,
+                    })
+                  }
                   className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
                 >
-                  {showPasswords.new ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                  {showPasswords.new ? (
+                    <EyeOff className="h-5 w-5" />
+                  ) : (
+                    <Eye className="h-5 w-5" />
+                  )}
                 </button>
               </div>
             </div>
@@ -384,18 +495,32 @@ const Profile: React.FC = () => {
               </label>
               <div className="relative">
                 <input
-                  type={showPasswords.confirm ? 'text' : 'password'}
+                  type={showPasswords.confirm ? "text" : "password"}
                   value={passwordForm.confirm_password}
-                  onChange={(e) => setPasswordForm({ ...passwordForm, confirm_password: e.target.value })}
+                  onChange={(e) =>
+                    setPasswordForm({
+                      ...passwordForm,
+                      confirm_password: e.target.value,
+                    })
+                  }
                   className="w-full p-4 pr-12 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
                   placeholder="Confirm new password"
                 />
                 <button
                   type="button"
-                  onClick={() => setShowPasswords({ ...showPasswords, confirm: !showPasswords.confirm })}
+                  onClick={() =>
+                    setShowPasswords({
+                      ...showPasswords,
+                      confirm: !showPasswords.confirm,
+                    })
+                  }
                   className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
                 >
-                  {showPasswords.confirm ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                  {showPasswords.confirm ? (
+                    <EyeOff className="h-5 w-5" />
+                  ) : (
+                    <Eye className="h-5 w-5" />
+                  )}
                 </button>
               </div>
             </div>
@@ -416,8 +541,12 @@ const Profile: React.FC = () => {
           <div className="flex items-center">
             <Shield className="h-5 w-5 text-yellow-600 mr-3" />
             <div>
-              <p className="font-medium text-yellow-800">Two-Factor Authentication</p>
-              <p className="text-sm text-yellow-600">Add an extra layer of security to your account</p>
+              <p className="font-medium text-yellow-800">
+                Two-Factor Authentication
+              </p>
+              <p className="text-sm text-yellow-600">
+                Add an extra layer of security to your account
+              </p>
             </div>
           </div>
           <button className="px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 transition-colors duration-200 text-sm font-medium">
@@ -434,10 +563,14 @@ const Profile: React.FC = () => {
               <div className="w-3 h-3 bg-emerald-500 rounded-full mr-3"></div>
               <div>
                 <p className="font-medium text-gray-900">Current Session</p>
-                <p className="text-sm text-gray-500">Chrome on Windows • Miami, FL</p>
+                <p className="text-sm text-gray-500">
+                  Chrome on Windows • Miami, FL
+                </p>
               </div>
             </div>
-            <span className="text-sm text-emerald-600 font-medium">Active now</span>
+            <span className="text-sm text-emerald-600 font-medium">
+              Active now
+            </span>
           </div>
           <div className="flex items-center justify-between p-4 bg-gray-50 rounded-xl">
             <div className="flex items-center">
@@ -458,11 +591,21 @@ const Profile: React.FC = () => {
 
   const renderPreferencesTab = () => (
     <div className="space-y-6">
-      <InfoCard title="Trading Portfolio">
+      <InfoCard
+        title="Trading Portfolio"
+        action={
+          <button
+            onClick={() => setShowPortfolioForm(!showPortfolioForm)}
+            className="px-3 py-2 text-sm bg-blue-600 text-white rounded-lg"
+          >
+            {showPortfolioForm ? "Cancel" : "Add"}
+          </button>
+        }
+      >
         <select
-          value={selectedPortfolio ?? ''}
+          value={selectedPortfolio ?? ""}
           onChange={(e) => changePortfolio(Number(e.target.value))}
-          className="w-full p-3 border border-gray-300 rounded-lg"
+          className="w-full p-3 border border-gray-300 rounded-lg mb-4"
         >
           {portfolios.map((p) => (
             <option key={p.id} value={p.id}>
@@ -470,24 +613,97 @@ const Profile: React.FC = () => {
             </option>
           ))}
         </select>
+        {showPortfolioForm && (
+          <div className="space-y-2">
+            <input
+              type="text"
+              placeholder="Name"
+              value={newPortfolio.name}
+              onChange={(e) =>
+                setNewPortfolio({ ...newPortfolio, name: e.target.value })
+              }
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+            <input
+              type="text"
+              placeholder="API Key"
+              value={newPortfolio.api_key}
+              onChange={(e) =>
+                setNewPortfolio({ ...newPortfolio, api_key: e.target.value })
+              }
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+            <input
+              type="text"
+              placeholder="Secret Key"
+              value={newPortfolio.secret_key}
+              onChange={(e) =>
+                setNewPortfolio({ ...newPortfolio, secret_key: e.target.value })
+              }
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+            <input
+              type="text"
+              placeholder="Base URL"
+              value={newPortfolio.base_url}
+              onChange={(e) =>
+                setNewPortfolio({ ...newPortfolio, base_url: e.target.value })
+              }
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+            <button
+              onClick={createPortfolio}
+              className="px-4 py-2 bg-emerald-600 text-white rounded-lg"
+            >
+              Save
+            </button>
+          </div>
+        )}
       </InfoCard>
       {/* Notifications */}
       <InfoCard title="Notification Preferences">
         <div className="space-y-4">
           {[
-            { title: 'Email Notifications', description: 'Receive email alerts for important events', enabled: true },
-            { title: 'Signal Alerts', description: 'Get notified when new trading signals arrive', enabled: true },
-            { title: 'Order Confirmations', description: 'Receive confirmations for executed orders', enabled: true },
-            { title: 'Weekly Reports', description: 'Get weekly performance summaries', enabled: false },
-            { title: 'Marketing Emails', description: 'Receive updates about new features', enabled: false },
+            {
+              title: "Email Notifications",
+              description: "Receive email alerts for important events",
+              enabled: true,
+            },
+            {
+              title: "Signal Alerts",
+              description: "Get notified when new trading signals arrive",
+              enabled: true,
+            },
+            {
+              title: "Order Confirmations",
+              description: "Receive confirmations for executed orders",
+              enabled: true,
+            },
+            {
+              title: "Weekly Reports",
+              description: "Get weekly performance summaries",
+              enabled: false,
+            },
+            {
+              title: "Marketing Emails",
+              description: "Receive updates about new features",
+              enabled: false,
+            },
           ].map((pref, index) => (
-            <div key={index} className="flex items-center justify-between p-4 bg-gray-50 rounded-xl">
+            <div
+              key={index}
+              className="flex items-center justify-between p-4 bg-gray-50 rounded-xl"
+            >
               <div>
                 <p className="font-medium text-gray-900">{pref.title}</p>
                 <p className="text-sm text-gray-500">{pref.description}</p>
               </div>
               <label className="relative inline-flex items-center cursor-pointer">
-                <input type="checkbox" defaultChecked={pref.enabled} className="sr-only peer" />
+                <input
+                  type="checkbox"
+                  defaultChecked={pref.enabled}
+                  className="sr-only peer"
+                />
                 <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
               </label>
             </div>
@@ -503,7 +719,9 @@ const Profile: React.FC = () => {
               <Download className="h-5 w-5 text-gray-500 mr-3" />
               <div>
                 <p className="font-medium text-gray-900">Export Data</p>
-                <p className="text-sm text-gray-500">Download your trading data and history</p>
+                <p className="text-sm text-gray-500">
+                  Download your trading data and history
+                </p>
               </div>
             </div>
             <button className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200 text-sm font-medium">
@@ -515,7 +733,9 @@ const Profile: React.FC = () => {
               <Upload className="h-5 w-5 text-gray-500 mr-3" />
               <div>
                 <p className="font-medium text-gray-900">Import Data</p>
-                <p className="text-sm text-gray-500">Import trading data from other platforms</p>
+                <p className="text-sm text-gray-500">
+                  Import trading data from other platforms
+                </p>
               </div>
             </div>
             <button className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-200 text-sm font-medium">
@@ -533,24 +753,69 @@ const Profile: React.FC = () => {
       <InfoCard title="Recent Activity">
         <div className="space-y-4">
           {[
-            { action: 'Login', description: 'Signed in from Chrome on Windows', time: '2 minutes ago', type: 'login' },
-            { action: 'Signal Processed', description: 'AAPL buy signal executed successfully', time: '1 hour ago', type: 'signal' },
-            { action: 'Profile Updated', description: 'Changed notification preferences', time: '3 hours ago', type: 'profile' },
-            { action: 'Order Filled', description: 'TSLA sell order completed', time: '5 hours ago', type: 'order' },
-            { action: 'Password Changed', description: 'Account password updated', time: '2 days ago', type: 'security' },
+            {
+              action: "Login",
+              description: "Signed in from Chrome on Windows",
+              time: "2 minutes ago",
+              type: "login",
+            },
+            {
+              action: "Signal Processed",
+              description: "AAPL buy signal executed successfully",
+              time: "1 hour ago",
+              type: "signal",
+            },
+            {
+              action: "Profile Updated",
+              description: "Changed notification preferences",
+              time: "3 hours ago",
+              type: "profile",
+            },
+            {
+              action: "Order Filled",
+              description: "TSLA sell order completed",
+              time: "5 hours ago",
+              type: "order",
+            },
+            {
+              action: "Password Changed",
+              description: "Account password updated",
+              time: "2 days ago",
+              type: "security",
+            },
           ].map((activity, index) => (
-            <div key={index} className="flex items-center p-4 bg-gray-50 rounded-xl">
-              <div className={`w-10 h-10 rounded-xl flex items-center justify-center mr-4 ${
-                activity.type === 'login' ? 'bg-blue-100' :
-                activity.type === 'signal' ? 'bg-emerald-100' :
-                activity.type === 'profile' ? 'bg-purple-100' :
-                activity.type === 'order' ? 'bg-orange-100' : 'bg-red-100'
-              }`}>
-                {activity.type === 'login' && <User className="h-5 w-5 text-blue-600" />}
-                {activity.type === 'signal' && <Activity className="h-5 w-5 text-emerald-600" />}
-                {activity.type === 'profile' && <Settings className="h-5 w-5 text-purple-600" />}
-                {activity.type === 'order' && <Briefcase className="h-5 w-5 text-orange-600" />}
-                {activity.type === 'security' && <Shield className="h-5 w-5 text-red-600" />}
+            <div
+              key={index}
+              className="flex items-center p-4 bg-gray-50 rounded-xl"
+            >
+              <div
+                className={`w-10 h-10 rounded-xl flex items-center justify-center mr-4 ${
+                  activity.type === "login"
+                    ? "bg-blue-100"
+                    : activity.type === "signal"
+                      ? "bg-emerald-100"
+                      : activity.type === "profile"
+                        ? "bg-purple-100"
+                        : activity.type === "order"
+                          ? "bg-orange-100"
+                          : "bg-red-100"
+                }`}
+              >
+                {activity.type === "login" && (
+                  <User className="h-5 w-5 text-blue-600" />
+                )}
+                {activity.type === "signal" && (
+                  <Activity className="h-5 w-5 text-emerald-600" />
+                )}
+                {activity.type === "profile" && (
+                  <Settings className="h-5 w-5 text-purple-600" />
+                )}
+                {activity.type === "order" && (
+                  <Briefcase className="h-5 w-5 text-orange-600" />
+                )}
+                {activity.type === "security" && (
+                  <Shield className="h-5 w-5 text-red-600" />
+                )}
               </div>
               <div className="flex-1">
                 <p className="font-medium text-gray-900">{activity.action}</p>
@@ -568,8 +833,12 @@ const Profile: React.FC = () => {
     <div className="p-8 bg-gray-50 min-h-screen max-w-7xl mx-auto">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Profile Settings</h1>
-        <p className="text-gray-600">Manage your account settings and trading preferences</p>
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          Profile Settings
+        </h1>
+        <p className="text-gray-600">
+          Manage your account settings and trading preferences
+        </p>
       </div>
 
       {/* Tabs */}
@@ -577,32 +846,32 @@ const Profile: React.FC = () => {
         <div className="flex flex-wrap gap-2">
           <TabButton
             tab="profile"
-            active={activeTab === 'profile'}
-            onClick={() => setActiveTab('profile')}
+            active={activeTab === "profile"}
+            onClick={() => setActiveTab("profile")}
             icon={User}
           >
             Profile
           </TabButton>
           <TabButton
             tab="security"
-            active={activeTab === 'security'}
-            onClick={() => setActiveTab('security')}
+            active={activeTab === "security"}
+            onClick={() => setActiveTab("security")}
             icon={Shield}
           >
             Security
           </TabButton>
           <TabButton
             tab="preferences"
-            active={activeTab === 'preferences'}
-            onClick={() => setActiveTab('preferences')}
+            active={activeTab === "preferences"}
+            onClick={() => setActiveTab("preferences")}
             icon={Settings}
           >
             Preferences
           </TabButton>
           <TabButton
             tab="activity"
-            active={activeTab === 'activity'}
-            onClick={() => setActiveTab('activity')}
+            active={activeTab === "activity"}
+            onClick={() => setActiveTab("activity")}
             icon={Activity}
           >
             Activity
@@ -611,10 +880,10 @@ const Profile: React.FC = () => {
       </div>
 
       {/* Tab Content */}
-      {activeTab === 'profile' && renderProfileTab()}
-      {activeTab === 'security' && renderSecurityTab()}
-      {activeTab === 'preferences' && renderPreferencesTab()}
-      {activeTab === 'activity' && renderActivityTab()}
+      {activeTab === "profile" && renderProfileTab()}
+      {activeTab === "security" && renderSecurityTab()}
+      {activeTab === "preferences" && renderPreferencesTab()}
+      {activeTab === "activity" && renderActivityTab()}
 
       {/* Danger Zone */}
       <div className="mt-8">
@@ -623,7 +892,9 @@ const Profile: React.FC = () => {
             <div className="flex items-center justify-between p-4 bg-red-50 rounded-xl border border-red-200">
               <div>
                 <h4 className="font-semibold text-red-900">Sign Out</h4>
-                <p className="text-sm text-red-600">Sign out from your current session</p>
+                <p className="text-sm text-red-600">
+                  Sign out from your current session
+                </p>
               </div>
               <button
                 onClick={logout}
@@ -635,7 +906,9 @@ const Profile: React.FC = () => {
             <div className="flex items-center justify-between p-4 bg-red-50 rounded-xl border border-red-200">
               <div>
                 <h4 className="font-semibold text-red-900">Delete Account</h4>
-                <p className="text-sm text-red-600">Permanently delete your account and all data</p>
+                <p className="text-sm text-red-600">
+                  Permanently delete your account and all data
+                </p>
               </div>
               <button className="px-6 py-3 border border-red-600 text-red-600 rounded-xl hover:bg-red-600 hover:text-white transition-all duration-200 font-medium">
                 Delete Account


### PR DESCRIPTION
## Summary
- support per-user portfolios with new DB field `Portfolio.user_id`
- allow any verified user to create and activate their own portfolios
- drop Alpaca credential fallback to env vars
- expose portfolio creation in profile page
- migration script for new column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68687827901c83319eec3790ed221b41