### PR TITLE
Fix clearing of Alpaca keys

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
     smtp_password: Optional[str] = None
     from_email: Optional[str] = None
 
+    def clear_alpaca_credentials(self) -> None:
+        """Reset Alpaca credentials to ensure no connections are made."""
+        self.alpaca_api_key = None
+        self.alpaca_secret_key = None
+
     def update_from_portfolio(self, portfolio) -> None:
         """Update Alpaca credentials from a Portfolio instance."""
         if portfolio:

--- a/app/schemas/trades.py
+++ b/app/schemas/trades.py
@@ -1,6 +1,6 @@
 # backend/app/schemas/trade.py
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional
 from datetime import datetime
 
@@ -19,8 +19,7 @@ class TradeSchema(BaseModel):
     pnl: Optional[float] = None
     user_id: Optional[int] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class EquityPointSchema(BaseModel):

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -45,6 +45,9 @@ def get_active(db: Session, user: User | None = None) -> Portfolio | None:
     if active:
         settings.update_from_portfolio(active)
         alpaca_client.refresh()
+    else:
+        settings.clear_alpaca_credentials()
+        alpaca_client.refresh()
     alpaca_stream.refresh()
     return active
 


### PR DESCRIPTION
## Summary
- reset Alpaca API credentials when there is no active portfolio
- expose helper on Settings for clearing credentials
- update Pydantic schema to use `ConfigDict`

## Testing
- `pip install -r app/requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688e3889d483318e18f7202685a743