### PR TITLE
Fix portfolio creation endpoint

### DIFF
--- a/app/api/v1/portfolios.py
+++ b/app/api/v1/portfolios.py
@@ -4,32 +4,35 @@ from ...database import get_db
 from ...services import portfolio_service
 from ...models.user import User
 from ...core.auth import get_current_verified_user
+from ...schemas.portfolio import PortfolioCreate, PortfolioResponse
 
 router = APIRouter()
 
 
-@router.get("/portfolios")
+@router.get("/portfolios", response_model=list[PortfolioResponse])
 def list_portfolios(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_verified_user),
 ):
     portfolios = portfolio_service.get_all(db, current_user)
-    return [{"id": p.id, "name": p.name, "is_active": p.is_active} for p in portfolios]
+    return portfolios
 
 
-@router.post("/portfolios")
+@router.post("/portfolios", response_model=PortfolioResponse)
 def create_portfolio(
-    name: str,
-    api_key: str,
-    secret_key: str,
-    base_url: str,
+    portfolio: PortfolioCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_verified_user),
 ):
-    portfolio = portfolio_service.create_portfolio(
-        db, current_user, name, api_key, secret_key, base_url
+    portfolio_obj = portfolio_service.create_portfolio(
+        db,
+        current_user,
+        portfolio.name,
+        portfolio.api_key,
+        portfolio.secret_key,
+        portfolio.base_url,
     )
-    return {"id": portfolio.id, "name": portfolio.name}
+    return portfolio_obj
 
 
 @router.post("/portfolios/{portfolio_id}/activate")

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, ConfigDict
+
+class PortfolioCreate(BaseModel):
+    name: str
+    api_key: str
+    secret_key: str
+    base_url: str
+
+
+class PortfolioResponse(BaseModel):
+    id: int
+    name: str
+    is_active: bool
+
+    model_config = ConfigDict(from_attributes=True)
+


### PR DESCRIPTION
## Summary
- add `PortfolioCreate` and `PortfolioResponse` schemas
- update portfolio routes to accept JSON and return typed models

## Testing
- `pip install -r app/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869281e04388331b4060a95fb56e095