### PR TITLE
Implement portfolio activation

### DIFF
--- a/app/api/v1/portfolios.py
+++ b/app/api/v1/portfolios.py
@@ -18,6 +18,17 @@ def list_portfolios(
     return portfolios
 
 
+@router.get("/portfolios/active", response_model=PortfolioResponse)
+def get_active_portfolio(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    active = portfolio_service.get_active(db, current_user)
+    if not active:
+        raise HTTPException(status_code=404, detail="No active portfolio")
+    return active
+
+
 @router.post("/portfolios", response_model=PortfolioResponse)
 def create_portfolio(
     portfolio: PortfolioCreate,

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -30,6 +30,17 @@ def create_portfolio(
     db.add(portfolio)
     db.commit()
     db.refresh(portfolio)
+
+    # If the user doesn't have an active portfolio yet, activate the new one
+    existing_active = (
+        db.query(Portfolio)
+        .filter_by(user_id=user.id, is_active=True)
+        .first()
+    )
+    if not existing_active:
+        activate_portfolio(db, user, portfolio.id)
+        db.refresh(portfolio)
+
     return portfolio
 
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -102,9 +102,10 @@ const Profile: React.FC = () => {
     });
     if (res.ok) {
       const data = await res.json();
-      setPortfolios([
-        ...portfolios,
-        { id: data.id, name: data.name, is_active: false },
+      await changePortfolio(data.id);
+      setPortfolios((prev) => [
+        ...prev.map((p) => ({ ...p, is_active: false })),
+        { id: data.id, name: data.name, is_active: true },
       ]);
       setShowPortfolioForm(false);
       setNewPortfolio({ name: "", api_key: "", secret_key: "", base_url: "" });


### PR DESCRIPTION
## Summary
- auto activate portfolio when no other active for the user
- expose API to retrieve the active portfolio
- activate newly created portfolio from the profile page

## Testing
- `pip install -r app/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869362e32ac83319d4e45f4576aaabf