### PR TITLE
Use per-user position limit on dashboard

### DIFF
--- a/app/api/v1/orders.py
+++ b/app/api/v1/orders.py
@@ -104,7 +104,9 @@ async def get_positions(
 ):
     """Ver posiciones actuales"""
     try:
-        portfolio_summary = position_manager.get_portfolio_summary()
+        portfolio_summary = position_manager.get_portfolio_summary(
+            current_user.position_limit
+        )
         portfolio_summary["user"] = current_user.username
         return portfolio_summary
     except Exception as e:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -64,7 +64,11 @@ def test_trade_update_triggers_broadcast(monkeypatch):
         messages.append(json.loads(msg))
     monkeypatch.setattr(ws_manager, 'broadcast', fake_broadcast)
     monkeypatch.setattr(stream_module.alpaca_client, 'get_account', lambda: DummyAccount())
-    monkeypatch.setattr(stream_module.position_manager, 'get_portfolio_summary', lambda: {'total_positions': 1})
+    monkeypatch.setattr(
+        stream_module.position_manager,
+        'get_portfolio_summary',
+        lambda *a, **k: {'total_positions': 1}
+    )
     alpaca_stream = stream_module.AlpacaStream()
     loop = asyncio.get_event_loop()
     loop.run_until_complete(alpaca_stream._handle_trade_update({}))


### PR DESCRIPTION
## Summary
- return portfolio summary using the current user's position_limit
- adjust websocket test to accept new argument

## Testing
- `pip install -r app/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68693fb332e0833189aaa0e92871d01c