### PR TITLE
Add admin user creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ credentials.
 Each user has a **position_limit** value determining how many open positions they
 may hold at once. The default limit is 7 and can be modified from the profile
 page or via the API.
+
+## Admin Setup
+
+Before starting the server, create an initial admin user:
+
+```bash
+python scripts/create_admin_user.py --email you@example.com --username admin --password yourpassword
+```

--- a/scripts/create_admin_user.py
+++ b/scripts/create_admin_user.py
@@ -1,0 +1,34 @@
+from app.database import SessionLocal
+from app.services.auth_service import auth_service
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create an admin user")
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--username", required=True)
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--full-name", dest="full_name")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        user = auth_service.create_user(
+            db=db,
+            email=args.email,
+            username=args.username,
+            password=args.password,
+            full_name=args.full_name,
+        )
+        user.is_admin = True
+        db.commit()
+        db.refresh(user)
+        print(
+            f"Admin user created: id={user.id} username={user.username} email={user.email}"
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper script to create an admin user
- document admin setup in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686948755f8483318374044dfa4740b3