### PR TITLE
Clean imports and fix ts warnings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import {
   BarChart3, Activity, List, Settings, Menu, X, LogOut, User,
-  Home, Briefcase, Bell, Search, ChevronRight,
-  Clock, RefreshCw, Target
+  Home, Briefcase, Bell, ChevronRight,
+  RefreshCw, Target
 } from 'lucide-react';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import AuthPage from './pages/AuthPage';
 import ProtectedRoute from './components/auth/ProtectedRoute';
-import Dashboard from './pages/Dashboard';
+import Dashboard from './pages/dashboard';
 import SignalsPage from './pages/signals';
 import OrdersPage from './pages/orders';
 import Profile from './pages/Profile';
@@ -221,14 +221,14 @@ const Sidebar: React.FC<{
 const MobileHeader: React.FC<{
   currentPage: Page;
   onToggleSidebar: () => void;
-  user: any;
-}> = ({ currentPage, onToggleSidebar, user }) => {
-  const pageNames = {
+}> = ({ currentPage, onToggleSidebar }) => {
+  const pageNames: Record<Page, string> = {
     dashboard: 'Dashboard',
     signals: 'Signals',
     orders: 'Orders',
     strategies: 'Strategies',
-    settings: 'Settings'
+    settings: 'Settings',
+    trades: 'Trades'
   };
 
   return (
@@ -265,18 +265,6 @@ const MobileHeader: React.FC<{
   );
 };
 
-// Componente temporal para páginas no implementadas
-const ComingSoon: React.FC<{ title: string }> = ({ title }) => (
-  <div className="flex-1 p-8 bg-gray-50 min-h-screen">
-    <div className="text-center py-20">
-      <div className="mx-auto h-24 w-24 text-gray-400 mb-4">
-        <Activity className="h-full w-full" />
-      </div>
-      <h3 className="text-lg font-medium text-gray-900 mb-2">{title}</h3>
-      <p className="text-gray-500">This page is coming soon...</p>
-    </div>
-  </div>
-);
 
 // Componente principal del dashboard autenticado
 const AuthenticatedApp: React.FC = () => {
@@ -285,7 +273,6 @@ const AuthenticatedApp: React.FC = () => {
 
   // ✅ NUEVO: Estado para contar signals pendientes
   const [pendingSignalsCount, setPendingSignalsCount] = useState(0);
-  const { user } = useAuth();
 
   // ✅ NUEVO: Función para obtener el count de signals
   useEffect(() => {
@@ -368,7 +355,6 @@ const AuthenticatedApp: React.FC = () => {
         <MobileHeader
           currentPage={currentPage}
           onToggleSidebar={() => setSidebarOpen(true)}
-          user={user}
         />
 
         {/* Page content */}

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,11 +1,12 @@
 // frontend/src/components/auth/ProtectedRoute.tsx
 
 import React from 'react';
+import type { ReactNode } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { RefreshCw } from 'lucide-react';
 
 interface ProtectedRouteProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {

--- a/frontend/src/components/auth/Register.tsx
+++ b/frontend/src/components/auth/Register.tsx
@@ -1,6 +1,7 @@
 // frontend/src/components/auth/Register.tsx
 
 import React, { useState } from 'react';
+import type { ReactNode } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { Eye, EyeOff, Mail, Lock, User, UserPlus, AlertCircle, CheckCircle, Info, RefreshCw } from 'lucide-react';
 
@@ -117,7 +118,7 @@ const Register: React.FC<RegisterProps> = ({ onToggleMode }) => {
     }
   };
 
-  const PasswordRequirement: React.FC<{ met: boolean; children: React.ReactNode }> = ({ met, children }) => (
+  const PasswordRequirement: React.FC<{ met: boolean; children: ReactNode }> = ({ met, children }) => (
     <div className={`flex items-center text-sm transition-colors duration-200 ${met ? 'text-green-600' : 'text-gray-500'}`}>
       {met ? (
         <CheckCircle className="h-4 w-4 mr-2" />

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 // frontend/src/contexts/AuthContext.tsx
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 
 interface User {
   id: number;
@@ -119,7 +120,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     console.log('✅ Login completed successfully'); // DEBUG
 
   } catch (error) {
-    if (error.name === 'AbortError') {
+    if (error instanceof Error && error.name === 'AbortError') {
       console.error('💥 Login timeout after 10 seconds'); // DEBUG
       throw new Error('Login request timed out. Please check your connection.');
     }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,11 +1,11 @@
 // frontend/src/pages/Profile.tsx
 
 import React, { useState } from "react";
+import type { ReactNode } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import {
   User,
   Mail,
-  Calendar,
   Shield,
   CheckCircle,
   XCircle,
@@ -13,7 +13,6 @@ import {
   Save,
   X,
   Key,
-  Bell,
   Download,
   Upload,
   Settings,
@@ -21,9 +20,6 @@ import {
   EyeOff,
   AlertTriangle,
   Camera,
-  MapPin,
-  Phone,
-  Globe,
   Briefcase,
   Award,
   Clock,
@@ -164,12 +160,11 @@ const Profile: React.FC = () => {
   if (!user) return null;
 
   const TabButton: React.FC<{
-    tab: string;
     active: boolean;
     onClick: () => void;
     icon: React.ComponentType<any>;
-    children: React.ReactNode;
-  }> = ({ tab, active, onClick, icon: Icon, children }) => (
+    children: ReactNode;
+  }> = ({ active, onClick, icon: Icon, children }) => (
     <button
       onClick={onClick}
       className={`flex items-center px-6 py-3 text-sm font-medium rounded-xl transition-all duration-200 ${
@@ -185,8 +180,8 @@ const Profile: React.FC = () => {
 
   const InfoCard: React.FC<{
     title: string;
-    children: React.ReactNode;
-    action?: React.ReactNode;
+    children: ReactNode;
+    action?: ReactNode;
   }> = ({ title, children, action }) => (
     <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
       <div className="flex items-center justify-between mb-4">
@@ -878,7 +873,6 @@ const Profile: React.FC = () => {
       <div className="mb-8">
         <div className="flex flex-wrap gap-2">
           <TabButton
-            tab="profile"
             active={activeTab === "profile"}
             onClick={() => setActiveTab("profile")}
             icon={User}
@@ -886,7 +880,6 @@ const Profile: React.FC = () => {
             Profile
           </TabButton>
           <TabButton
-            tab="security"
             active={activeTab === "security"}
             onClick={() => setActiveTab("security")}
             icon={Shield}
@@ -894,7 +887,6 @@ const Profile: React.FC = () => {
             Security
           </TabButton>
           <TabButton
-            tab="preferences"
             active={activeTab === "preferences"}
             onClick={() => setActiveTab("preferences")}
             icon={Settings}
@@ -902,7 +894,6 @@ const Profile: React.FC = () => {
             Preferences
           </TabButton>
           <TabButton
-            tab="activity"
             active={activeTab === "activity"}
             onClick={() => setActiveTab("activity")}
             icon={Activity}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { connectWebSocket } from '../services/ws';
 import {
   BarChart3, DollarSign, TrendingUp, Activity, AlertCircle, RefreshCw,
-  CheckCircle, XCircle, ArrowUp, ArrowDown, PieChart, Target, Briefcase,
+  ArrowUp, ArrowDown, PieChart, Target, Briefcase,
   Clock, Shield, Zap
 } from 'lucide-react';
 import EquityCurveChart from '../components/EquityCurveChart';
@@ -177,9 +177,6 @@ const formatCurrency = (value: string | number | null | undefined) => {
   }).format(num);
 };
 
-const formatTime = (timestamp: string) => {
-  return new Date(timestamp).toLocaleString();
-};
 
 // Component: Enhanced Stats Card
 const StatsCard: React.FC<{
@@ -429,10 +426,6 @@ const TradingDashboard: React.FC = () => {
     positive: true
   } : undefined;
 
-  const dayChange = account ? {
-    value: '+$1,250',
-    positive: true
-  } : undefined;
 
   if (loading) {
     return (

--- a/frontend/src/pages/orders.tsx
+++ b/frontend/src/pages/orders.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 import {
   BarChart3, CheckCircle, XCircle, Clock, AlertCircle, RefreshCw, Filter,
   TrendingUp, TrendingDown, Search, Download, Calendar, DollarSign,
-  ArrowUp, ArrowDown, Eye, MoreHorizontal, Target, Zap, PieChart,
-  PlayCircle, Settings2
+  ArrowUp, ArrowDown, Eye, MoreHorizontal, Target, PieChart
 } from 'lucide-react';
 import Pagination from '../components/Pagination';
 
@@ -166,7 +166,7 @@ const OrdersPage: React.FC = () => {
   const FilterButton: React.FC<{
     active: boolean;
     onClick: () => void;
-    children: React.ReactNode;
+    children: ReactNode;
     count?: number;
   }> = ({ active, onClick, children, count }) => (
     <button
@@ -190,7 +190,7 @@ const OrdersPage: React.FC = () => {
   const TimeRangeButton: React.FC<{
     active: boolean;
     onClick: () => void;
-    children: React.ReactNode;
+    children: ReactNode;
   }> = ({ active, onClick, children }) => (
     <button
       onClick={onClick}
@@ -252,9 +252,6 @@ const OrdersPage: React.FC = () => {
       }).format(num);
     };
 
-    const formatTime = (timestamp: string) => {
-      return new Date(timestamp).toLocaleString();
-    };
 
     return (
       <tr className="hover:bg-gray-50 transition-colors duration-200 group">

--- a/frontend/src/pages/signals.tsx
+++ b/frontend/src/pages/signals.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 import { connectWebSocket } from '../services/ws';
 import {
   Activity, CheckCircle, XCircle, Clock, AlertCircle, RefreshCw, Filter,
-  Search, TrendingUp, TrendingDown, Zap, BarChart3, Target,
+  Search, TrendingUp, TrendingDown,
   ArrowUp, ArrowDown, Calendar, Eye, Settings2
 } from 'lucide-react';
 import Pagination from '../components/Pagination';
@@ -165,7 +166,7 @@ const SignalsPage: React.FC = () => {
   const FilterButton: React.FC<{
     active: boolean;
     onClick: () => void;
-    children: React.ReactNode;
+    children: ReactNode;
     count?: number;
   }> = ({ active, onClick, children, count }) => (
     <button


### PR DESCRIPTION
## Summary
- remove unused icons and modules across React pages
- fix path case for dashboard page import
- tighten type usage for page names and ReactNode
- ensure error checks use `instanceof Error`

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68696810368483319e4266189f411ac2