### PR TITLE
Remove dotenv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository contains a trading bot built with FastAPI and Alpaca.
 Alpaca credentials are stored securely in the database. Each user can create
 their own portfolios from the frontend or via the API and select which one is
 active. The application no longer falls back to environment variables for
-credentials.
+credentials. Configuration now relies on environment variables provided by the
+shell; a `.env` file is no longer loaded automatically.
 
 Each user has a **position_limit** value determining how many open positions they
 may hold at once. The default limit is 7 and can be modified from the profile

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,5 @@
 from pydantic_settings import BaseSettings
 from typing import Optional
-import os
-from dotenv import load_dotenv
 import base64
 import hashlib
 
@@ -9,10 +7,6 @@ try:
     from cryptography.fernet import Fernet
 except Exception:
     Fernet = None
-
-# Cargar el archivo .env manualmente
-load_dotenv()
-
 
 class Settings(BaseSettings):
     # Database
@@ -30,7 +24,7 @@ class Settings(BaseSettings):
     # App
     app_name: str = "Trading Bot"
     debug: bool = True
-    secret_key: str
+    secret_key: str = "changeme"
 
     # Webhook
     webhook_secret: Optional[str] = None
@@ -74,10 +68,5 @@ class Settings(BaseSettings):
 
     def __init__(self, **values):
         super().__init__(**values)
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- drop `.env` loading and remove the pydantic `env_file` configuration
- set a default value for `secret_key`
- clarify in README that environment variables should be provided via the shell

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869778919dc8331a4180dd9a958e0bc