### PR TITLE
Use relative API routes

### DIFF
--- a/frontend/public/portfolio-monitor.html
+++ b/frontend/public/portfolio-monitor.html
@@ -30,7 +30,7 @@
         const token = localStorage.getItem('token');
         if (!token) return;
         try {
-          const res = await fetch('http://localhost:8000/api/v1/account', {
+          const res = await fetch('/api/v1/account', {
             headers: { 'Authorization': `Bearer ${token}` }
           });
           if (!res.ok) return;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -281,7 +281,7 @@ const AuthenticatedApp: React.FC = () => {
         const token = localStorage.getItem('token');
         if (!token) return;
 
-        const response = await fetch('http://localhost:8000/api/v1/signals', {
+        const response = await fetch('/api/v1/signals', {
           headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json',

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -34,7 +34,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const API_BASE_URL = 'http://localhost:8000/api/v1';
+const API_BASE_URL = '/api/v1';
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -62,7 +62,7 @@ const Profile: React.FC = () => {
   });
   const [positionLimit, setPositionLimit] = useState<number>(user?.position_limit ?? 7);
 
-  const API_BASE_URL = "http://localhost:8000/api/v1";
+  const API_BASE_URL = "/api/v1";
 
   React.useEffect(() => {
     const fetchPortfolios = async () => {

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -115,7 +115,7 @@ const authenticatedFetch = async (url: string, options: RequestInit = {}) => {
 
 // API Service con autenticación
 const api = {
-  baseUrl: 'http://localhost:8000/api/v1',
+  baseUrl: '/api/v1',
 
   async getAccount(): Promise<Account | null> {
     console.log('🔄 Fetching account data...');

--- a/frontend/src/pages/orders.tsx
+++ b/frontend/src/pages/orders.tsx
@@ -101,7 +101,7 @@ const OrdersPage: React.FC = () => {
       setError(null);
 
       console.log('🔄 Fetching orders...');
-      const response = await authenticatedFetch('http://localhost:8000/api/v1/orders');
+      const response = await authenticatedFetch('/api/v1/orders');
       const data = await response.json();
 
       if (Array.isArray(data.orders)) {

--- a/frontend/src/pages/signals.tsx
+++ b/frontend/src/pages/signals.tsx
@@ -100,7 +100,7 @@ const SignalsPage: React.FC = () => {
       setError(null);
 
       console.log('🔄 Fetching signals...');
-      const response = await authenticatedFetch('http://localhost:8000/api/v1/signals');
+      const response = await authenticatedFetch('/api/v1/signals');
       const data = await response.json();
 
       console.log('✅ Signals fetched successfully:', data);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
 // frontend/src/services/api.ts
 
-const API_BASE_URL = 'http://localhost:8000/api/v1';
+const API_BASE_URL = '/api/v1';
 
 // Función para obtener el token del localStorage
 const getAuthToken = (): string | null => {

--- a/frontend/src/services/ws.ts
+++ b/frontend/src/services/ws.ts
@@ -6,7 +6,8 @@ export interface WSHandlers {
 }
 
 export const connectWebSocket = (handlers: WSHandlers) => {
-  const ws = new WebSocket('ws://localhost:8000/ws/updates');
+  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(`${protocol}://${window.location.host}/ws/updates`);
   ws.onmessage = (event) => {
     try {
       const msg = JSON.parse(event.data);


### PR DESCRIPTION
## Summary
- switch hardcoded localhost URLs to relative `/api` paths
- connect websocket using current host

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68698767485483319918a41bcec94b76