### PR TITLE
Add Kraken broker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # EllenTradingBot v2
 
-This repository contains a trading bot built with FastAPI and Alpaca. 
+This repository contains a trading bot built with FastAPI. It now supports
+Alpaca and Kraken as brokers.
 
 ## Configuration
 
-Alpaca credentials are stored securely in the database. Each user can create
+Broker credentials are stored securely in the database. Each user can create
 their own portfolios from the frontend or via the API and select which one is
 active. The application no longer falls back to environment variables for
 credentials. Configuration now relies on environment variables provided by the
 shell; a `.env` file is no longer loaded automatically.
+
+To use **Kraken** instead of Alpaca, create a portfolio whose `base_url`
+contains `api.kraken.com` and provide your Kraken API and secret keys. The
+library `python-kraken-sdk` is required and listed in `requirements.txt`.
 
 Each user has a **position_limit** value determining how many open positions they
 may hold at once. The default limit is 7 and can be modified from the profile

--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -1,0 +1,18 @@
+from app.config import settings
+from .alpaca.client import alpaca_client
+from .kraken.client import kraken_client
+
+
+def _select_client():
+    if settings.kraken_api_key and settings.kraken_secret_key:
+        return kraken_client
+    return alpaca_client
+
+
+broker_client = _select_client()
+
+
+def refresh_broker_client():
+    """Update the global ``broker_client`` reference based on settings."""
+    global broker_client
+    broker_client = _select_client()

--- a/app/integrations/kraken/__init__.py
+++ b/app/integrations/kraken/__init__.py
@@ -1,0 +1,3 @@
+from .client import kraken_client
+
+__all__ = ["kraken_client"]

--- a/app/integrations/kraken/client.py
+++ b/app/integrations/kraken/client.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+"""Kraken integration client mirroring the AlpacaClient interface."""
+
+from types import SimpleNamespace
+from kraken.spot import Market, Trade, User
+from app.config import settings
+
+
+class KrakenClient:
+    def __init__(self) -> None:
+        self.market_client: Market | None = None
+        self.trade_client: Trade | None = None
+        self.user_client: User | None = None
+        if settings.kraken_api_key and settings.kraken_secret_key:
+            self._init_clients()
+
+    def _init_clients(self) -> None:
+        self.market_client = Market()
+        self.trade_client = Trade(
+            key=settings.kraken_api_key,
+            secret=settings.kraken_secret_key,
+            url=settings.kraken_base_url,
+        )
+        self.user_client = User(
+            key=settings.kraken_api_key,
+            secret=settings.kraken_secret_key,
+            url=settings.kraken_base_url,
+        )
+
+    def _ensure_clients(self) -> None:
+        if self.trade_client is None:
+            if not settings.kraken_api_key or not settings.kraken_secret_key:
+                raise RuntimeError("Kraken API credentials not configured")
+            self._init_clients()
+
+    def refresh(self) -> None:
+        """Recreate clients with current settings credentials."""
+        if settings.kraken_api_key and settings.kraken_secret_key:
+            self._init_clients()
+        else:
+            self.market_client = None
+            self.trade_client = None
+            self.user_client = None
+
+    # --- Basic account helpers -------------------------------------------------
+    def get_account(self):
+        """Return a simplified account object with cash metrics."""
+        self._ensure_clients()
+        balances = self.user_client.get_account_balance()
+        cash = float(balances.get("ZUSD", balances.get("USD", 0)))
+        return SimpleNamespace(cash=cash, buying_power=cash, portfolio_value=cash)
+
+    def get_positions(self):
+        """Return current asset balances as positions."""
+        self._ensure_clients()
+        balances = self.user_client.get_account_balance()
+        return [
+            SimpleNamespace(symbol=s, qty=float(q))
+            for s, q in balances.items()
+            if float(q) > 0
+        ]
+
+    def get_position(self, symbol: str):
+        """Get balance for a single symbol."""
+        self._ensure_clients()
+        qty = float(self.user_client.get_account_balance().get(symbol, 0))
+        if qty:
+            return SimpleNamespace(symbol=symbol, qty=qty)
+        return None
+
+    # --- Trading ---------------------------------------------------------------
+    def is_crypto_symbol(self, symbol: str) -> bool:
+        return True
+
+    def submit_order(self, symbol, qty, side, order_type="market"):
+        return self.submit_crypto_order(symbol, qty, side, order_type)
+
+    def submit_crypto_order(self, symbol, qty, side, order_type="market"):
+        """Create a crypto order on Kraken."""
+        self._ensure_clients()
+        resp = self.trade_client.create_order(
+            pair=symbol,
+            type=side,
+            ordertype=order_type,
+            volume=str(qty),
+        )
+        txid = ""
+        if isinstance(resp, dict):
+            txid = resp.get("result", {}).get("txid", "")
+            if isinstance(txid, list):
+                txid = txid[0]
+        return SimpleNamespace(id=txid, symbol=symbol, qty=qty, side=side)
+
+    # --- Market data -----------------------------------------------------------
+    def get_latest_crypto_quote(self, symbol: str):
+        """Fetch the latest ask and bid for ``symbol``."""
+        self._ensure_clients()
+        info = self.market_client.get_ticker(pair=symbol)
+        data = next(iter(info.values()))
+        ask = float(data["a"][0])
+        bid = float(data["b"][0])
+        return SimpleNamespace(ask_price=ask, bid_price=bid)
+
+    def get_latest_quote(self, symbol: str):
+        return self.get_latest_crypto_quote(symbol)
+
+    # --- Misc -----------------------------------------------------------------
+    def list_orders(self, status="all", limit=10):
+        self._ensure_clients()
+        orders = []
+        if status in ("all", "open"):
+            res = self.user_client.get_open_orders()
+            orders.extend(res.get("open", {}).values())
+        if status in ("all", "closed"):
+            res = self.user_client.get_closed_orders()
+            orders.extend(res.get("closed", {}).values())
+        return orders[:limit]
+
+    def is_asset_fractionable(self, symbol):
+        return True
+
+    def check_crypto_status(self):
+        return True
+
+    def get_crypto_assets(self):
+        self._ensure_clients()
+        assets = self.market_client.get_assets()
+        return list(assets.keys())
+
+    def get_latest_trade(self, symbol):
+        return self.get_latest_crypto_quote(symbol)
+
+    def list_assets(self, status="active", asset_class="crypto"):
+        self._ensure_clients()
+        assets = self.market_client.get_assets()
+        return [SimpleNamespace(symbol=s) for s in assets.keys()]
+
+    def get_asset(self, symbol):
+        self._ensure_clients()
+        assets = self.market_client.get_assets()
+        if symbol in assets:
+            return SimpleNamespace(symbol=symbol)
+        return None
+
+    @property
+    def api(self):
+        return self.trade_client
+
+
+# Global instance
+kraken_client = KrakenClient()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -24,6 +24,7 @@ python-jose[cryptography]==3.3.0
 cryptography==45.0.5
 passlib[bcrypt]==1.7.4
 werkzeug==3.0.1
+python-kraken-sdk==3.2.2
 
 # Testing
 pytest==7.4.3

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -4,6 +4,8 @@ from app.models.user import User
 from app.config import settings
 from app.integrations.alpaca.client import alpaca_client
 from app.integrations.alpaca.stream import alpaca_stream
+from app.integrations.kraken.client import kraken_client
+from app.integrations import refresh_broker_client
 import base64
 import hashlib
 from cryptography.fernet import Fernet
@@ -56,10 +58,14 @@ def get_active(db: Session, user: User | None = None) -> Portfolio | None:
     if active:
         settings.update_from_portfolio(active)
         alpaca_client.refresh()
+        kraken_client.refresh()
     else:
         settings.clear_alpaca_credentials()
+        settings.clear_kraken_credentials()
         alpaca_client.refresh()
+        kraken_client.refresh()
     alpaca_stream.refresh()
+    refresh_broker_client()
     return active
 
 
@@ -71,4 +77,6 @@ def activate_portfolio(db: Session, user: User, portfolio_id: int):
     active = db.query(Portfolio).filter_by(id=portfolio_id, user_id=user.id).first()
     settings.update_from_portfolio(active)
     alpaca_client.refresh()
+    kraken_client.refresh()
     alpaca_stream.refresh()
+    refresh_broker_client()

--- a/app/services/trade_service.py
+++ b/app/services/trade_service.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from sqlalchemy.orm import Session
 from app.models.trades import Trade
-from app.integrations.alpaca.client import alpaca_client
+
 
 
 class TradeService:
@@ -12,7 +12,8 @@ class TradeService:
 
     def __init__(self, db: Session):
         self.db = db
-        self.alpaca = alpaca_client
+        from app.integrations import broker_client
+        self.alpaca = broker_client
 
     def _map_symbol(self, symbol: str) -> str:
         return self.SYMBOL_MAP.get(symbol, symbol)

--- a/check_orders.py
+++ b/check_orders.py
@@ -1,14 +1,14 @@
 # check_orders.py
 
-from app.integrations.alpaca.client import alpaca_client
+from app.integrations import broker_client
 
 
 def run():
-    print("🔍 Verificando órdenes en Alpaca...")
-    orders = alpaca_client.list_orders(status='all', limit=10)
+    print("🔍 Verificando órdenes en broker...")
+    orders = broker_client.list_orders(status='all', limit=10)
 
     if not orders:
-        print("⚠️ No hay órdenes en Alpaca.")
+        print("⚠️ No hay órdenes en el broker.")
         return
 
     for o in orders:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ uvicorn[standard]==0.24.0
 werkzeug==3.0.1
 pytest==7.4.3
 pytest-asyncio==0.21.1
+python-kraken-sdk==3.2.2

--- a/tests/test_position_limit.py
+++ b/tests/test_position_limit.py
@@ -18,14 +18,14 @@ class DummyPM:
     def get_position_quantity(self, symbol):
         return 0
 
-class DummyAlpaca:
+class DummyBroker:
     def get_account(self):
         return types.SimpleNamespace(cash="1000")
 
 
 def test_order_blocked_when_limit_exceeded(monkeypatch):
     oe = OrderExecutor()
-    monkeypatch.setattr(oe, 'alpaca', DummyAlpaca())
+    monkeypatch.setattr(oe, 'broker', DummyBroker())
     oe.position_manager = DummyPM(open_positions=2)
 
     user = User(id=1, email="a@b.c", username="u", position_limit=2)


### PR DESCRIPTION
## Summary
- implement `KrakenClient` and generic broker client
- extend settings for Kraken credentials
- refresh broker on portfolio activation
- update services and CLI to use the generic client
- document Kraken support and new dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab01091d48331ac7a2274f636922e