### PR TITLE
Update default DB connection

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -84,7 +84,7 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
-sqlalchemy.url = postgresql://postgres:ellentrading@localhost/ellentradingv2
+sqlalchemy.url = postgresql://postgres:ellentrading@localhost:5432/ellentrading
 
 
 [post_write_hooks]

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ except Exception:
 
 class Settings(BaseSettings):
     # Database
-    database_url: str = "sqlite:///./trading_bot.db"
+    database_url: str = "postgresql://postgres:ellentrading@localhost:5432/ellentrading"
 
     # Redis
     redis_url: str = "redis://localhost:6379"


### PR DESCRIPTION
## Summary
- default to Postgres database in configuration
- adjust Alembic configuration accordingly

## Testing
- `PYTHONPATH=. pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_686afad13d108331a9c2ef1e8cf5084f