### PR TITLE
Fix secret key persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ env/
 # Otros
 *.DS_Store
 *.bak
+secret.key

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ active. The application no longer falls back to environment variables for
 credentials. Configuration now relies on environment variables provided by the
 shell; a `.env` file is no longer loaded automatically.
 
+If the `SECRET_KEY` environment variable is not set, the application will
+generate a new key and store it in a `secret.key` file. Keeping this file
+around ensures that encrypted portfolio credentials remain decryptable across
+restarts.
+
 Create a portfolio whose `base_url` contains `api.kraken.com` and provide your
 Kraken API and secret keys. The library `python-kraken-sdk` is required and
 listed in `requirements.txt`.

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,27 @@
 from pydantic_settings import BaseSettings
 from typing import Optional
+from pydantic import Field
 import base64
 import hashlib
+import os
+import secrets
+from pathlib import Path
+
+
+def _load_secret_key() -> str:
+    """Load the SECRET_KEY from env or generate a persistent one."""
+    env_key = os.getenv("SECRET_KEY")
+    if env_key:
+        return env_key
+    key_file = Path("secret.key")
+    if key_file.exists():
+        return key_file.read_text().strip()
+    if Fernet:
+        new_key = Fernet.generate_key().decode()
+    else:
+        new_key = secrets.token_urlsafe(32)
+    key_file.write_text(new_key)
+    return new_key
 
 try:
     from cryptography.fernet import Fernet
@@ -23,7 +43,7 @@ class Settings(BaseSettings):
     # App
     app_name: str = "Trading Bot"
     debug: bool = True
-    secret_key: str = "changeme"
+    secret_key: str = Field(default_factory=_load_secret_key)
 
     # Webhook
     webhook_secret: Optional[str] = None


### PR DESCRIPTION
## Summary
- generate or load persistent `SECRET_KEY` if none provided
- ignore generated `secret.key`
- document secret key persistence in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b05a204c08331aa88359369f425a4