### PR TITLE
Fix Kraken base URL handling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -84,7 +84,10 @@ class Settings(BaseSettings):
 
             self.kraken_api_key = api_key
             self.kraken_secret_key = secret_key
-            self.kraken_base_url = portfolio.base_url
+            base_url = portfolio.base_url.rstrip('/')
+            if base_url.endswith('/0'):
+                base_url = base_url[:-2]
+            self.kraken_base_url = base_url
 
     def __init__(self, **values):
         super().__init__(**values)


### PR DESCRIPTION
## Summary
- sanitize Kraken base URL on portfolio loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a0bc0c083319eb1ddd5cbd29a6d