### PR TITLE
Add SOLUSD mapping

### DIFF
--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -30,6 +30,7 @@ class OrderExecutor:
         symbol_map = {
             'BTCUSD': 'BTC/USD',
             'ETHUSD': 'ETH/USD',
+            'SOLUSD': 'SOL/USD',
         }
         mapped = symbol_map.get(symbol, symbol)
         print(f"🔄 Symbol mapping: {symbol} -> {mapped}")

--- a/app/services/trade_service.py
+++ b/app/services/trade_service.py
@@ -8,6 +8,7 @@ class TradeService:
     SYMBOL_MAP = {
         'BTCUSD': 'BTC/USD',
         'ETHUSD': 'ETH/USD',
+        'SOLUSD': 'SOL/USD',
     }
 
     def __init__(self, db: Session):


### PR DESCRIPTION
## Summary
- map `SOLUSD` to `SOL/USD` in order executor and trade service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b36bbaa488331acc9ec840725270a