### PR TITLE
Fix Kraken position lookup for crypto pairs

### DIFF
--- a/tests/test_kraken_client.py
+++ b/tests/test_kraken_client.py
@@ -1,0 +1,20 @@
+import os
+os.environ.setdefault('SECRET_KEY', 'secret')
+
+from app.integrations.kraken.client import KrakenClient
+
+
+def test_get_position_alt_symbols(monkeypatch):
+    client = KrakenClient()
+
+    def fake_private_post(endpoint, data=None):
+        if endpoint == "Balance":
+            return {"XETH": "1.25", "ZUSD": "1000"}
+        return {}
+
+    monkeypatch.setattr(client, "_private_post", fake_private_post)
+
+    pos = client.get_position("ETH/USD")
+    assert pos is not None
+    assert pos.qty == 1.25
+


### PR DESCRIPTION
## Summary
- improve Kraken client `get_position` to search for alternate asset codes
- add unit test covering the new lookup

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx<0.27`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db7106a4483318bbf0ac1c29057ba