### PR TITLE
Integrate recent orders panel into dashboard

### DIFF
--- a/frontend/src/components/recent_orders_panel.tsx
+++ b/frontend/src/components/recent_orders_panel.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { TrendingUp, TrendingDown, Activity } from 'lucide-react';
+
+interface Order {
+  id: string;
+  symbol: string;
+  qty: string;
+  side: string;
+  status: string;
+  submitted_at: string;
+  filled_at?: string;
+  rejected_reason?: string;
+}
+
+const OrderItem: React.FC<{ order: Order }> = ({ order }) => {
+  const sideBg = order.side === 'buy' ? 'bg-emerald-100' : 'bg-red-100';
+  const sideIcon = order.side === 'buy' ? (
+    <TrendingUp className="h-5 w-5 text-emerald-600" />
+  ) : (
+    <TrendingDown className="h-5 w-5 text-red-600" />
+  );
+
+  const statusColor =
+    order.status === 'filled'
+      ? 'bg-emerald-100 text-emerald-800'
+      : order.status === 'rejected'
+      ? 'bg-red-100 text-red-800'
+      : 'bg-blue-100 text-blue-800';
+
+  return (
+    <div className="flex items-center justify-between p-4 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors duration-200">
+      <div className="flex items-center">
+        <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${sideBg}`}>{sideIcon}</div>
+        <div className="ml-3">
+          <p className="font-semibold text-gray-900">{order.symbol}</p>
+          <p className="text-sm text-gray-600">{order.qty} units</p>
+        </div>
+      </div>
+      <div className="text-right">
+        <span className={`px-3 py-1 rounded-full text-xs font-medium ${statusColor}`}>{order.status}</span>
+        <p className="text-xs text-gray-500 mt-1">{new Date(order.submitted_at).toLocaleTimeString()}</p>
+      </div>
+    </div>
+  );
+};
+
+const RecentOrdersPanel: React.FC<{ orders: Order[] }> = ({ orders }) => {
+  const displayed = Array.isArray(orders) ? orders.slice(0, 5) : [];
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-lg font-semibold text-gray-900">Recent Orders</h3>
+        <span className="text-sm text-gray-500">{orders.length} total</span>
+      </div>
+      <div className="space-y-4">
+        {displayed.length === 0 ? (
+          <div className="text-center py-8">
+            <Activity className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+            <p className="text-gray-500">No orders found</p>
+          </div>
+        ) : (
+          displayed.map((o) => <OrderItem key={o.id} order={o} />)
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RecentOrdersPanel;

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -8,6 +8,7 @@ import {
 import EquityCurveChart from '../components/EquityCurveChart';
 import type { EquityPoint } from '../components/EquityCurveChart';
 import WinRateSpeedometer from '../components/winrate_speedometer';
+import RecentOrdersPanel from '../components/recent_orders_panel';
 
 // Tipos TypeScript
 interface Account {
@@ -376,6 +377,7 @@ const TradingDashboard: React.FC = () => {
   const [portfolio, setPortfolio] = useState<PortfolioData | null>(null);
   const [equityCurve, setEquityCurve] = useState<EquityPoint[]>([]);
   const [trades, setTrades] = useState<Trade[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
   const [winRate, setWinRate] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -391,12 +393,13 @@ const TradingDashboard: React.FC = () => {
         throw new Error('No authentication token found. Please log in again.');
       }
 
-      const [accountData, signalsData, portfolioData, equityData, tradesData] = await Promise.all([
+      const [accountData, signalsData, portfolioData, equityData, tradesData, ordersData] = await Promise.all([
         api.getAccount(),
         api.getSignals(),
         api.getPositions(),
         api.getEquityCurve(),
-        api.getTrades()
+        api.getTrades(),
+        api.getOrders()
       ]);
 
       console.log('✅ All data fetched successfully');
@@ -406,6 +409,7 @@ const TradingDashboard: React.FC = () => {
       setPortfolio(portfolioData);
       setEquityCurve(equityData);
       setTrades(tradesData);
+      setOrders(ordersData);
 
       const closedTrades = tradesData.filter((t) => t.status === 'closed');
       const winningTrades = closedTrades.filter((t) => t.pnl !== null && t.pnl > 0);
@@ -540,27 +544,29 @@ const TradingDashboard: React.FC = () => {
 
 
       {/* Activity Sections */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
-        {/* Recent Signals */}
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-lg font-semibold text-gray-900">Recent Signals</h3>
-            <span className="text-sm text-gray-500">{signals.length} total</span>
-          </div>
-          <div className="space-y-4">
-            {signals.length === 0 ? (
-              <div className="text-center py-8">
-                <Activity className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-                <p className="text-gray-500">No signals received yet</p>
-                <p className="text-sm text-gray-400">Signals from TradingView will appear here</p>
-              </div>
-            ) : (
-              signals.slice(0, 3).map((signal) => (
-                <ActivityItem key={signal.id} type="signal" data={signal} />
-              ))
-            )}
-          </div>
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mb-8">
+        <div className="flex items-center justify-between mb-6">
+          <h3 className="text-lg font-semibold text-gray-900">Recent Signals</h3>
+          <span className="text-sm text-gray-500">{signals.length} total</span>
         </div>
+        <div className="space-y-4">
+          {signals.length === 0 ? (
+            <div className="text-center py-8">
+              <Activity className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+              <p className="text-gray-500">No signals received yet</p>
+              <p className="text-sm text-gray-400">Signals from TradingView will appear here</p>
+            </div>
+          ) : (
+            signals.slice(0, 3).map((signal) => (
+              <ActivityItem key={signal.id} type="signal" data={signal} />
+            ))
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+        {/* Recent Orders */}
+        <RecentOrdersPanel orders={orders} />
 
         {/* Win Rate */}
         <WinRateSpeedometer winRate={winRate} totalTrades={trades.filter((t) => t.status === 'closed').length} />


### PR DESCRIPTION
## Summary
- add `RecentOrdersPanel` component for showing the latest orders
- fetch orders in dashboard and render next to the win rate gauge

## Testing
- `npm run lint` *(fails: @eslint/js missing, many lint errors)*
- `pytest -q` *(fails: ModuleNotFoundError: requests, sqlalchemy, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6870305bbc6c83318d373c4a0235b6f3