### PR TITLE
Fix dashboard panel sizes

### DIFF
--- a/frontend/src/components/active_trades_panel.tsx
+++ b/frontend/src/components/active_trades_panel.tsx
@@ -87,7 +87,7 @@ const ActiveTradesPanel = ({ trades = [] }: ActiveTradesPanelProps) => {
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 h-fit">
+    <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 w-full h-full">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">

--- a/frontend/src/components/winrate_speedometer.tsx
+++ b/frontend/src/components/winrate_speedometer.tsx
@@ -95,7 +95,7 @@ const WinRateSpeedometer: React.FC<WinRateProps> = ({ winRate = 68.5, totalTrade
   const needleY = 150 + 80 * Math.sin((angle - 90) * Math.PI / 180);
 
   return (
-    <div className="flex flex-col items-center p-6 bg-white rounded-xl shadow-lg border border-gray-200 max-w-md mx-auto">
+    <div className="flex flex-col items-center p-6 bg-white rounded-xl shadow-lg border border-gray-200 w-full h-full">
       {/* Header */}
       <div className="text-center mb-4">
         <div className="flex items-center justify-center gap-2 mb-2">

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -561,7 +561,7 @@ const TradingDashboard: React.FC = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8 auto-rows-fr">
         {/* Active Trades */}
         <ActiveTradesPanel trades={trades.filter((t) => t.status === 'open')} />
 


### PR DESCRIPTION
## Summary
- make active trades section take full available space
- update win rate panel sizing
- use auto-row heights on trading dashboard

## Testing
- `pytest -q` *(fails: Client.__init__ got unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687071be993c8331a74460a53d539496