### PR TITLE
Add BCH/USD symbol support

### DIFF
--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -31,6 +31,7 @@ class OrderExecutor:
             'BTCUSD': 'BTC/USD',
             'ETHUSD': 'ETH/USD',
             'SOLUSD': 'SOL/USD',
+            'BCHUSD': 'BCH/USD',
         }
         mapped = symbol_map.get(symbol, symbol)
         print(f"🔄 Symbol mapping: {symbol} -> {mapped}")

--- a/app/services/trade_service.py
+++ b/app/services/trade_service.py
@@ -9,6 +9,7 @@ class TradeService:
         'BTCUSD': 'BTC/USD',
         'ETHUSD': 'ETH/USD',
         'SOLUSD': 'SOL/USD',
+        'BCHUSD': 'BCH/USD',
     }
 
     def __init__(self, db: Session):

--- a/tests/test_symbol_mapping.py
+++ b/tests/test_symbol_mapping.py
@@ -1,0 +1,11 @@
+from app.services.trade_service import TradeService
+from app.services.order_executor import OrderExecutor
+
+
+def test_bchusd_mapping():
+    service = TradeService.__new__(TradeService)
+    assert service.SYMBOL_MAP.get('BCHUSD') == 'BCH/USD'
+
+    oe = OrderExecutor()
+    mapped = oe.map_symbol('BCHUSD')
+    assert mapped == 'BCH/USD'


### PR DESCRIPTION
## Summary
- map `BCHUSD` to `BCH/USD` for Kraken orders
- include `BCHUSD` pair in trade service and order executor mappings
- test that BCH mapping is recognized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871be7a423083319bc98c0378647469