### PR TITLE
Fix type-only import for EquityPoint

### DIFF
--- a/frontend/src/pages/strategies.tsx
+++ b/frontend/src/pages/strategies.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { RefreshCw } from 'lucide-react';
 import api from '../services/api';
-import EquityCurveChart, { EquityPoint } from '../components/EquityCurveChart';
+import EquityCurveChart, { type EquityPoint } from '../components/EquityCurveChart';
 
 interface Strategy {
   id: number;


### PR DESCRIPTION
## Summary
- fix import in `strategies.tsx` to satisfy TypeScript `verbatimModuleSyntax`

## Testing
- `npm run build`
- `pytest -q` *(fails: TypeError in tests/test_websocket.py)*

------
https://chatgpt.com/codex/tasks/task_e_68729f82ece88331b9dbb9df77ddb848