### PR TITLE
Add risk management dashboard

### DIFF
--- a/app/api/v1/risk.py
+++ b/app/api/v1/risk.py
@@ -1,0 +1,134 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.models.user import User
+from app.core.auth import get_current_verified_user
+from app.services.risk_manager import risk_manager
+from app.services.position_manager import position_manager
+
+router = APIRouter()
+
+@router.get("/risk/status")
+async def get_risk_status(current_user: User = Depends(get_current_verified_user)):
+    """Get current risk management status and allocation info"""
+    try:
+        from app.integrations import broker_client
+        account = broker_client.get_account()
+        buying_power = float(getattr(account, "buying_power", 0))
+        portfolio_value = float(getattr(account, "portfolio_value", 0))
+
+        allocation_info = risk_manager.get_allocation_info(buying_power)
+
+        # Build detailed positions
+        raw_positions = position_manager.get_current_positions()
+        position_details = []
+        for symbol, qty in raw_positions.items():
+            if abs(float(qty)) < 0.001:
+                continue
+            try:
+                quote = broker_client.get_latest_crypto_quote(symbol)
+                price = float(getattr(quote, "ask_price", getattr(quote, "ap", 0)))
+            except Exception:
+                price = 0.0
+            market_value = price * float(qty)
+            position_details.append({
+                "symbol": symbol,
+                "quantity": float(qty),
+                "market_value": market_value,
+                "unrealized_pl": 0.0,
+                "percentage": (market_value / portfolio_value * 100) if portfolio_value > 0 else 0,
+            })
+
+        # Simulate next positions
+        symbols_to_simulate = ["BTC/USD", "ETH/USD", "SOL/USD", "BCH/USD"]
+        next_positions_simulation = []
+        for symbol in symbols_to_simulate:
+            try:
+                if "/" in symbol:
+                    quote = broker_client.get_latest_crypto_quote(symbol)
+                    price = float(getattr(quote, "ask_price", getattr(quote, "ap", 100000)))
+                else:
+                    price = 50000
+                simulated_qty = risk_manager.calculate_optimal_position_size(
+                    price=price,
+                    buying_power=buying_power,
+                    symbol=symbol,
+                )
+                simulated_value = simulated_qty * price
+                minimum_qty = risk_manager.get_symbol_minimum(symbol)
+                next_positions_simulation.append({
+                    "symbol": symbol,
+                    "current_price": price,
+                    "would_buy_qty": simulated_qty,
+                    "would_invest_usd": simulated_value,
+                    "minimum_required": minimum_qty,
+                    "can_enter": simulated_qty >= minimum_qty,
+                    "percentage_of_portfolio": (simulated_value / buying_power * 100) if buying_power > 0 else 0,
+                })
+            except Exception as e:
+                print(f"Error simulating {symbol}: {e}")
+                continue
+
+        return {
+            "account_info": {
+                "buying_power": buying_power,
+                "portfolio_value": portfolio_value,
+                "cash_percentage": (buying_power / portfolio_value * 100) if portfolio_value > 0 else 100,
+            },
+            "allocation_info": allocation_info,
+            "current_positions": position_details,
+            "risk_metrics": {
+                "position_count": len(position_details),
+                "capital_utilization": ((portfolio_value - buying_power) / portfolio_value * 100) if portfolio_value > 0 else 0,
+                "largest_position_pct": max([p["percentage"] for p in position_details], default=0),
+                "concentration_risk": "High" if any(p["percentage"] > 40 for p in position_details) else "Medium" if any(p["percentage"] > 25 for p in position_details) else "Low",
+            },
+            "next_positions_simulation": next_positions_simulation,
+        }
+    except Exception as e:
+        print(f"Error getting risk status: {e}")
+        return {"error": str(e)}
+
+@router.get("/risk/allocation-chart")
+async def get_allocation_chart_data(current_user: User = Depends(get_current_verified_user)):
+    """Get data for allocation pie chart"""
+    try:
+        raw_positions = position_manager.get_current_positions()
+        from app.integrations import broker_client
+        account = broker_client.get_account()
+        buying_power = float(getattr(account, "buying_power", 0))
+
+        chart_data = []
+        for symbol, qty in raw_positions.items():
+            if float(qty) <= 0:
+                continue
+            try:
+                quote = broker_client.get_latest_crypto_quote(symbol)
+                price = float(getattr(quote, "ask_price", getattr(quote, "ap", 0)))
+            except Exception:
+                price = 0.0
+            market_value = price * float(qty)
+            if market_value > 0:
+                chart_data.append({
+                    "name": symbol,
+                    "value": market_value,
+                    "color": _get_symbol_color(symbol),
+                })
+        if buying_power > 0:
+            chart_data.append({
+                "name": "Available Cash",
+                "value": buying_power,
+                "color": "#10B981",
+            })
+        return {"chart_data": chart_data}
+    except Exception as e:
+        return {"error": str(e)}
+
+def _get_symbol_color(symbol: str) -> str:
+    colors = {
+        "BTC/USD": "#F59E0B",
+        "ETH/USD": "#6366F1",
+        "SOL/USD": "#8B5CF6",
+        "BCH/USD": "#10B981",
+    }
+    return colors.get(symbol, "#6B7280")

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from app.api.v1.trades import router as trades_router
 from app.api.v1.strategies import router as strategies_router
 from app.api.v1.portfolios import router as portfolios_router
 from app.api.v1.streaming import router as streaming_router
+from app.api.v1 import risk
 from app.api.ws import router as ws_router
 from app.database import SessionLocal
 from app.services import portfolio_service
@@ -34,6 +35,7 @@ app.include_router(strategies_router, prefix="/api/v1", tags=["strategies"])
 app.include_router(auth_router, prefix="/api/v1/auth", tags=["authentication"])
 app.include_router(portfolios_router, prefix="/api/v1", tags=["portfolios"])
 app.include_router(streaming_router, prefix="/api/v1", tags=["streaming"])
+app.include_router(risk.router, prefix="/api/v1", tags=["risk"])
 app.include_router(ws_router)
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   BarChart3, Activity, List, Settings, Menu, X, LogOut, User,
   Home, Briefcase, Bell, ChevronRight,
-  RefreshCw, Target
+  RefreshCw, Target, Shield
 } from 'lucide-react';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import AuthPage from './pages/AuthPage';
@@ -13,9 +13,10 @@ import OrdersPage from './pages/orders';
 import Profile from './pages/Profile';
 import TradesPage from './pages/trades';
 import StrategiesPage from './pages/strategies';
+import RiskDashboard from './pages/RiskDashboard';
 
 // Tipos para las páginas
-type Page = 'dashboard' | 'signals' | 'orders' | 'trades' | 'strategies' | 'settings';
+type Page = 'dashboard' | 'signals' | 'orders' | 'trades' | 'strategies' | 'risk' | 'settings';
 
 // Componente de navegación mejorado
 const Sidebar: React.FC<{
@@ -62,6 +63,13 @@ const Sidebar: React.FC<{
       name: 'Strategies',
       icon: Target,
       description: 'Strategy configs',
+      badge: null
+    },
+    {
+      id: 'risk' as Page,
+      name: 'Risk',
+      icon: Shield,
+      description: 'Risk management',
       badge: null
     },
     {
@@ -331,6 +339,8 @@ const AuthenticatedApp: React.FC = () => {
         return <TradesPage />;
       case 'strategies':
         return <StrategiesPage />;
+      case 'risk':
+        return <RiskDashboard />;
       case 'settings':
         return <Profile />;
       default:

--- a/frontend/src/pages/RiskDashboard.tsx
+++ b/frontend/src/pages/RiskDashboard.tsx
@@ -1,0 +1,293 @@
+import React, { useEffect, useState } from 'react';
+import { Shield, AlertTriangle, DollarSign, PieChart, Target, RefreshCw, Calculator } from 'lucide-react';
+import api from '../services/api';
+
+interface RiskStatus {
+  account_info: {
+    buying_power: number;
+    portfolio_value: number;
+    cash_percentage: number;
+  };
+  allocation_info: {
+    available_capital: number;
+    open_positions: number;
+    reserved_slots: number;
+    capital_per_position: number;
+    next_position_percentage: number;
+  };
+  current_positions: Array<{
+    symbol: string;
+    quantity: number;
+    market_value: number;
+    unrealized_pl: number;
+    percentage: number;
+  }>;
+  risk_metrics: {
+    position_count: number;
+    capital_utilization: number;
+    largest_position_pct: number;
+    concentration_risk: string;
+  };
+  next_positions_simulation: Array<{
+    symbol: string;
+    current_price: number;
+    would_buy_qty: number;
+    would_invest_usd: number;
+    minimum_required: number;
+    can_enter: boolean;
+    percentage_of_portfolio: number;
+  }>;
+}
+
+const RiskDashboard: React.FC = () => {
+  const [riskStatus, setRiskStatus] = useState<RiskStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
+
+  const fetchRiskStatus = async () => {
+    try {
+      const response = await api.risk.getStatus();
+      if (!response.ok) throw new Error('Failed to fetch risk status');
+      const data = await response.json();
+      setRiskStatus(data);
+      setLastUpdate(new Date());
+    } catch (error) {
+      console.error('Error loading risk status:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRiskStatus();
+    const interval = setInterval(fetchRiskStatus, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-8 bg-gray-50 min-h-screen max-w-7xl mx-auto">
+        <div className="flex flex-col items-center py-12">
+          <RefreshCw className="h-8 w-8 animate-spin text-blue-600 mb-2" />
+          <p className="text-gray-600">Loading risk dashboard...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!riskStatus) {
+    return (
+      <div className="p-8 bg-gray-50 min-h-screen max-w-7xl mx-auto">
+        <div className="text-center py-12">
+          <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <p className="text-gray-600">Failed to load risk data</p>
+          <button
+            onClick={fetchRiskStatus}
+            className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const { account_info, allocation_info, current_positions, risk_metrics, next_positions_simulation } = riskStatus;
+
+  return (
+    <div className="p-8 bg-gray-50 min-h-screen max-w-7xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center space-x-3">
+          <Shield className="h-8 w-8 text-blue-600" />
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Risk Management</h1>
+            <p className="text-sm text-gray-500">
+              Last updated: {lastUpdate.toLocaleTimeString()}
+            </p>
+          </div>
+        </div>
+
+        <button
+          onClick={fetchRiskStatus}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2"
+        >
+          <RefreshCw className="h-4 w-4" />
+          <span>Refresh</span>
+        </button>
+      </div>
+
+      {/* Top Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        <div className="bg-white p-6 rounded-xl shadow">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-600">Available Capital</p>
+              <p className="text-2xl font-bold text-green-600">
+                ${account_info.buying_power.toLocaleString()}
+              </p>
+            </div>
+            <DollarSign className="h-8 w-8 text-green-600" />
+          </div>
+        </div>
+
+        <div className="bg-white p-6 rounded-xl shadow">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-600">Open Positions</p>
+              <p className="text-2xl font-bold text-blue-600">
+                {allocation_info.open_positions}
+              </p>
+            </div>
+            <Target className="h-8 w-8 text-blue-600" />
+          </div>
+        </div>
+
+        <div className="bg-white p-6 rounded-xl shadow">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-600">Next Position Size</p>
+              <p className="text-2xl font-bold text-purple-600">
+                ${allocation_info.capital_per_position.toLocaleString()}
+              </p>
+              <p className="text-xs text-gray-500">
+                {allocation_info.next_position_percentage.toFixed(1)}% of capital
+              </p>
+            </div>
+            <Calculator className="h-8 w-8 text-purple-600" />
+          </div>
+        </div>
+
+        <div className="bg-white p-6 rounded-xl shadow">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-600">Risk Level</p>
+              <p
+                className={`text-2xl font-bold ${
+                  risk_metrics.concentration_risk === 'High'
+                    ? 'text-red-600'
+                    : risk_metrics.concentration_risk === 'Medium'
+                    ? 'text-yellow-600'
+                    : 'text-green-600'
+                }`}
+              >
+                {risk_metrics.concentration_risk}
+              </p>
+            </div>
+            <AlertTriangle
+              className={`h-8 w-8 ${
+                risk_metrics.concentration_risk === 'High'
+                  ? 'text-red-600'
+                  : risk_metrics.concentration_risk === 'Medium'
+                  ? 'text-yellow-600'
+                  : 'text-green-600'
+              }`}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* Current Positions */}
+        <div className="bg-white p-6 rounded-xl shadow">
+          <h3 className="text-lg font-semibold mb-4 flex items-center">
+            <PieChart className="h-5 w-5 mr-2" />
+            Current Positions
+          </h3>
+
+          {current_positions.length === 0 ? (
+            <p className="text-gray-500 text-center py-8">No open positions</p>
+          ) : (
+            <div className="space-y-3">
+              {current_positions.map((position) => (
+                <div
+                  key={position.symbol}
+                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                >
+                  <div>
+                    <p className="font-medium">{position.symbol}</p>
+                    <p className="text-sm text-gray-600">
+                      {position.quantity} units • {position.percentage.toFixed(1)}%
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-medium">
+                      ${position.market_value.toLocaleString()}
+                    </p>
+                    <p
+                      className={`text-sm ${
+                        position.unrealized_pl >= 0 ? 'text-green-600' : 'text-red-600'
+                      }`}
+                    >
+                      {position.unrealized_pl >= 0 ? '+' : ''}
+                      ${position.unrealized_pl.toFixed(2)}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Next Positions Simulation */}
+        <div className="bg-white p-6 rounded-xl shadow">
+          <h3 className="text-lg font-semibold mb-4 flex items-center">
+            <Calculator className="h-5 w-5 mr-2" />
+            Next Signal Simulation
+          </h3>
+
+          <div className="space-y-3">
+            {next_positions_simulation.map((sim) => (
+              <div
+                key={sim.symbol}
+                className={`p-3 rounded-lg border-2 ${
+                  sim.can_enter ? 'border-green-200 bg-green-50' : 'border-red-200 bg-red-50'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{sim.symbol}</p>
+                    <p className="text-sm text-gray-600">
+                      @ ${sim.current_price.toLocaleString()}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    {sim.can_enter ? (
+                      <>
+                        <p className="font-medium text-green-600">
+                          ${sim.would_invest_usd.toFixed(0)}
+                        </p>
+                        <p className="text-sm text-gray-600">
+                          {sim.would_buy_qty.toFixed(6)} units
+                        </p>
+                      </>
+                    ) : (
+                      <p className="text-sm text-red-600">Insufficient capital</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Smart Allocation Info */}
+      <div className="mt-8 bg-white p-6 rounded-xl shadow">
+        <h3 className="text-lg font-semibold mb-4">Smart Allocation Formula</h3>
+        <div className="bg-blue-50 p-4 rounded-lg">
+          <p className="text-center text-lg font-mono">
+            Capital per Position = ${allocation_info.available_capital.toLocaleString()} ÷
+            ({allocation_info.open_positions} positions + {allocation_info.reserved_slots} reserved) =
+            <span className="font-bold text-blue-600"> ${allocation_info.capital_per_position.toLocaleString()}</span>
+          </p>
+          <p className="text-center text-sm text-gray-600 mt-2">
+            Reserved slots ensure capital availability for future opportunities
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RiskDashboard;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -104,6 +104,16 @@ export const api = {
     },
   },
 
+  // Risk endpoints
+  risk: {
+    getStatus: async () => {
+      return authenticatedFetch(`${API_BASE_URL}/risk/status`);
+    },
+    getAllocationChart: async () => {
+      return authenticatedFetch(`${API_BASE_URL}/risk/allocation-chart`);
+    },
+  },
+
   // Strategy endpoints
   strategies: {
     list: async () => {


### PR DESCRIPTION
## Summary
- implement backend endpoints for risk status and allocation chart
- integrate risk router in FastAPI main app
- create new React page `RiskDashboard`
- update navigation and API service to include risk endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c00100b88331aa7009a9d103b7e4