### PR TITLE
Fix missing 'risk' page label

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -235,6 +235,7 @@ const MobileHeader: React.FC<{
     signals: 'Signals',
     orders: 'Orders',
     strategies: 'Strategies',
+    risk: 'Risk',
     settings: 'Settings',
     trades: 'Trades'
   };


### PR DESCRIPTION
## Summary
- add `risk` name to mobile header page name map

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6872c399d1208331b49d6557c397dbea