### PR TITLE
Add Alpaca broker support in settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,14 @@ class Settings(BaseSettings):
     kraken_secret_key: Optional[str] = None
     kraken_base_url: str = "https://api.kraken.com"
 
+    # Alpaca
+    alpaca_api_key: Optional[str] = None
+    alpaca_secret_key: Optional[str] = None
+    alpaca_base_url: str = "https://paper-api.alpaca.markets"
+
+    # Active broker identifier
+    active_broker: Optional[str] = None
+
     # App
     app_name: str = "Trading Bot"
     debug: bool = True
@@ -66,9 +74,21 @@ class Settings(BaseSettings):
     from_email: Optional[str] = None
 
     def clear_kraken_credentials(self) -> None:
-        """Reset Kraken credentials."""
+        """Reset credentials based on the currently active broker."""
+        if self.active_broker == "alpaca":
+            self.clear_alpaca_credentials()
+            return
         self.kraken_api_key = None
         self.kraken_secret_key = None
+        if self.active_broker == "kraken":
+            self.active_broker = None
+
+    def clear_alpaca_credentials(self) -> None:
+        """Reset Alpaca credentials."""
+        self.alpaca_api_key = None
+        self.alpaca_secret_key = None
+        if self.active_broker == "alpaca":
+            self.active_broker = None
 
     def update_from_portfolio(self, portfolio) -> None:
         """Update API credentials from a Portfolio instance."""
@@ -93,12 +113,24 @@ class Settings(BaseSettings):
                 api_key = portfolio.api_key_encrypted
                 secret_key = portfolio.secret_key_encrypted
 
-            self.kraken_api_key = api_key
-            self.kraken_secret_key = secret_key
-            base_url = portfolio.base_url.rstrip('/')
-            if base_url.endswith('/0'):
+            base_url = portfolio.base_url.rstrip("/")
+            if base_url.endswith("/0"):
                 base_url = base_url[:-2]
-            self.kraken_base_url = base_url
+
+            if "alpaca.markets" in base_url:
+                self.alpaca_api_key = api_key
+                self.alpaca_secret_key = secret_key
+                self.alpaca_base_url = base_url
+                self.kraken_api_key = None
+                self.kraken_secret_key = None
+                self.active_broker = "alpaca"
+            else:
+                self.kraken_api_key = api_key
+                self.kraken_secret_key = secret_key
+                self.kraken_base_url = base_url
+                self.alpaca_api_key = None
+                self.alpaca_secret_key = None
+                self.active_broker = "kraken"
 
     def __init__(self, **values):
         super().__init__(**values)


### PR DESCRIPTION
## Summary
- extend `Settings` with Alpaca credentials and `active_broker`
- clear credentials respecting the active broker
- choose credentials in `update_from_portfolio`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d286936d883319b2d322d7f9d681d