### PR TITLE
Implement broker client refresh

### DIFF
--- a/app/api/v1/streaming.py
+++ b/app/api/v1/streaming.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.integrations.kraken import kraken_stream
+from app.integrations import broker_stream
 
 router = APIRouter()
 
@@ -8,5 +8,5 @@ router = APIRouter()
 @router.post("/stream/subscribe/{symbol}")
 async def subscribe_symbol(symbol: str):
     """Subscribe to real time trades for a given symbol."""
-    kraken_stream.subscribe(symbol)
+    broker_stream.subscribe(symbol)
     return {"status": "subscribed", "symbol": symbol}

--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -1,9 +1,27 @@
-from .kraken.client import kraken_client
+"""Integration facade exposing the active broker client and stream."""
+
+from .alpaca import alpaca_client, alpaca_stream
+from .kraken import kraken_client, kraken_stream
+from app.config import settings
 
 
 broker_client = kraken_client
+broker_stream = kraken_stream
 
 
 def refresh_broker_client() -> None:
-    """Refresh the global broker client instance."""
-    kraken_client.refresh()
+    """Refresh and switch the global broker client/stream based on settings."""
+    global broker_client, broker_stream
+
+    if settings.active_broker == "alpaca":
+        alpaca_client.refresh()
+        broker_client = alpaca_client
+        broker_stream = alpaca_stream
+    else:
+        kraken_client.refresh()
+        broker_client = kraken_client
+        broker_stream = kraken_stream
+
+
+# Initialize the broker globals on import
+refresh_broker_client()

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.api.v1 import risk
 from app.api.ws import router as ws_router
 from app.database import SessionLocal
 from app.services import portfolio_service
+from app.integrations import refresh_broker_client
 
 app = FastAPI(
     title=settings.app_name,
@@ -47,6 +48,7 @@ async def start_streams():
         portfolio_service.get_active(db)
     finally:
         db.close()
+    refresh_broker_client()
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
## Summary
- switch broker integrations based on `settings.active_broker`
- use the active stream for `/stream/subscribe`
- refresh broker settings at startup

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d2c238b088331aa8e2aceaf5e729b