### PR TITLE
Implement broker stream export

### DIFF
--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -4,6 +4,8 @@ from .alpaca import alpaca_client, alpaca_stream
 from .kraken import kraken_client, kraken_stream
 from app.config import settings
 
+__all__ = ["broker_client", "broker_stream", "refresh_broker_client"]
+
 
 broker_client = kraken_client
 broker_stream = kraken_stream


### PR DESCRIPTION
## Summary
- export `broker_stream` from `integrations` via `__all__`
- `streaming.py` already imports and uses `broker_stream`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2ed883e48331968c1996125b66eb