### PR TITLE
Add Alpaca tests and generic broker usage

### DIFF
--- a/tests/test_alpaca_client.py
+++ b/tests/test_alpaca_client.py
@@ -1,0 +1,25 @@
+import os
+os.environ.setdefault('SECRET_KEY', 'secret')
+
+from app.integrations.alpaca.client import AlpacaClient
+
+
+def test_get_position(monkeypatch):
+    client = AlpacaClient()
+
+    class DummyPos:
+        def __init__(self, symbol, qty):
+            self.symbol = symbol
+            self.qty = qty
+
+    class DummyTrading:
+        def get_open_position(self, symbol):
+            assert symbol == "AAPL"
+            return DummyPos(symbol, "3.5")
+
+    monkeypatch.setattr(client, "_trading", DummyTrading())
+
+    pos = client.get_position("AAPL")
+    assert pos is not None
+    assert pos.qty == 3.5
+


### PR DESCRIPTION
## Summary
- add Alpaca client unit tests using dummy trading client
- adjust stream tests to use integrations.broker_stream generically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3045d7d083319489e1a025bb88fc