### PR TITLE
Add alpaca-trade-api dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ restarts.
 Create a portfolio whose `base_url` contains `api.kraken.com` and provide your
 Kraken API and secret keys. The library `python-kraken-sdk` is required and
 listed in `requirements.txt`.
+For trading with Alpaca, install the stable `alpaca-trade-api` package,
+also included in `requirements.txt` and `app/requirements.txt`.
 
 Each user has a **position_limit** value determining how many open positions they
 may hold at once. The default limit is 7 and can be modified from the profile

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -24,6 +24,7 @@ passlib[bcrypt]==1.7.4
 werkzeug==3.0.1
 python-kraken-sdk==3.2.2
 alpaca-py==0.42.0
+alpaca-trade-api==3.2.0
 
 # Testing
 pytest==7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ python-kraken-sdk==3.2.2
 websockets==15.0.1
 aiohttp==3.12.13
 alpaca-py==0.42.0
+alpaca-trade-api==3.2.0


### PR DESCRIPTION
## Summary
- add alpaca-trade-api to main requirements
- include alpaca-trade-api in app requirements
- document alpaca-trade-api install in README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r app/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d35307c4483319dd3a975b9596fc4