### PR TITLE
Add broker column to portfolios

### DIFF
--- a/alembic/versions/8db7b36ec533_add_broker_column.py
+++ b/alembic/versions/8db7b36ec533_add_broker_column.py
@@ -1,0 +1,32 @@
+"""add broker column
+
+Revision ID: 8db7b36ec533
+Revises: b11273efc639
+Create Date: 2025-07-20 19:09:05.905403
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8db7b36ec533'
+down_revision: Union[str, Sequence[str], None] = 'b11273efc639'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "portfolios",
+        sa.Column("broker", sa.String(length=20), nullable=False, server_default="kraken"),
+    )
+    op.alter_column("portfolios", "broker", server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("portfolios", "broker")

--- a/app/api/v1/portfolios.py
+++ b/app/api/v1/portfolios.py
@@ -42,6 +42,7 @@ def create_portfolio(
         portfolio.api_key,
         portfolio.secret_key,
         portfolio.base_url,
+        portfolio.broker,
     )
     return portfolio_obj
 

--- a/app/config.py
+++ b/app/config.py
@@ -117,7 +117,11 @@ class Settings(BaseSettings):
             if base_url.endswith("/0"):
                 base_url = base_url[:-2]
 
-            if "alpaca.markets" in base_url:
+            broker = getattr(portfolio, "broker", None)
+            if not broker:
+                broker = "alpaca" if "alpaca.markets" in base_url else "kraken"
+
+            if broker == "alpaca":
                 self.alpaca_api_key = api_key
                 self.alpaca_secret_key = secret_key
                 self.alpaca_base_url = base_url

--- a/app/models/portfolio.py
+++ b/app/models/portfolio.py
@@ -11,6 +11,7 @@ class Portfolio(Base):
     api_key_encrypted = Column(String(255), nullable=False)
     secret_key_encrypted = Column(String(255), nullable=False)
     base_url = Column(String(255), nullable=False)
+    broker = Column(String(20), nullable=False, default="kraken")
     is_active = Column(Boolean, default=False)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
 

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -5,12 +5,14 @@ class PortfolioCreate(BaseModel):
     api_key: str
     secret_key: str
     base_url: str
+    broker: str | None = None
 
 
 class PortfolioResponse(BaseModel):
     id: int
     name: str
     is_active: bool
+    broker: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -18,14 +18,27 @@ def _get_fernet():
 
 
 def create_portfolio(
-    db: Session, user: User, name: str, api_key: str, secret_key: str, base_url: str
+    db: Session,
+    user: User,
+    name: str,
+    api_key: str,
+    secret_key: str,
+    base_url: str,
+    broker: str | None = None,
 ) -> Portfolio:
     f = _get_fernet()
+    if broker is None:
+        url_lower = base_url.lower()
+        if "alpaca" in url_lower:
+            broker = "alpaca"
+        else:
+            broker = "kraken"
     portfolio = Portfolio(
         name=name,
         api_key_encrypted=f.encrypt(api_key.encode()).decode(),
         secret_key_encrypted=f.encrypt(secret_key.encode()).decode(),
         base_url=base_url,
+        broker=broker,
         user_id=user.id,
     )
     db.add(portfolio)


### PR DESCRIPTION
## Summary
- add broker column to `Portfolio` model
- include broker in Portfolio schemas and API
- infer broker when creating portfolios
- update settings to use stored broker
- create Alembic migration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3e0d178c83319192060e6a940417