### PR TITLE
Support Alpaca paper/live mode from portfolio

### DIFF
--- a/alembic/versions/a518a2a016b9_add_is_paper_column.py
+++ b/alembic/versions/a518a2a016b9_add_is_paper_column.py
@@ -1,0 +1,21 @@
+"""add is_paper column to portfolio"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'a518a2a016b9'
+down_revision: Union[str, Sequence[str], None] = '8db7b36ec533'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "portfolios",
+        sa.Column("is_paper", sa.Boolean(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("portfolios", "is_paper")

--- a/app/api/v1/portfolios.py
+++ b/app/api/v1/portfolios.py
@@ -43,6 +43,7 @@ def create_portfolio(
         portfolio.secret_key,
         portfolio.base_url,
         portfolio.broker,
+        portfolio.is_paper,
     )
     return portfolio_obj
 

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,7 @@ class Settings(BaseSettings):
     alpaca_api_key: Optional[str] = None
     alpaca_secret_key: Optional[str] = None
     alpaca_base_url: str = "https://paper-api.alpaca.markets"
+    alpaca_paper: bool = True
 
     # Active broker identifier
     active_broker: Optional[str] = None
@@ -120,11 +121,15 @@ class Settings(BaseSettings):
             broker = getattr(portfolio, "broker", None)
             if not broker:
                 broker = "alpaca" if "alpaca.markets" in base_url else "kraken"
+            paper = getattr(portfolio, "is_paper", None)
+            if paper is None and broker == "alpaca":
+                paper = "paper" in base_url.lower()
 
             if broker == "alpaca":
                 self.alpaca_api_key = api_key
                 self.alpaca_secret_key = secret_key
                 self.alpaca_base_url = base_url
+                self.alpaca_paper = bool(paper)
                 self.kraken_api_key = None
                 self.kraken_secret_key = None
                 self.active_broker = "alpaca"
@@ -134,6 +139,7 @@ class Settings(BaseSettings):
                 self.kraken_base_url = base_url
                 self.alpaca_api_key = None
                 self.alpaca_secret_key = None
+                self.alpaca_paper = True
                 self.active_broker = "kraken"
 
     def __init__(self, **values):

--- a/app/integrations/alpaca/client.py
+++ b/app/integrations/alpaca/client.py
@@ -31,11 +31,14 @@ class AlpacaClient:
         self.api_key = getattr(settings, "alpaca_api_key", None) or ""
         self.api_secret = getattr(settings, "alpaca_secret_key", None) or ""
         self.base_url = getattr(settings, "alpaca_base_url", None)
+        paper_mode = getattr(settings, "alpaca_paper", None)
+        if paper_mode is None:
+            paper_mode = "paper" in (self.base_url or "").lower()
         if self.api_key and self.api_secret:
             self._trading = TradingClient(
                 self.api_key,
                 self.api_secret,
-                paper=True,
+                paper=paper_mode,
                 url_override=self.base_url,
             )
             self._stock_data = StockHistoricalDataClient(self.api_key, self.api_secret)

--- a/app/integrations/alpaca/stream.py
+++ b/app/integrations/alpaca/stream.py
@@ -22,7 +22,11 @@ class AlpacaStream:
         key = getattr(settings, "alpaca_api_key", None)
         secret = getattr(settings, "alpaca_secret_key", None)
         if key and secret:
-            self._stream = TradingStream(key, secret, paper=True)
+            base_url = getattr(settings, "alpaca_base_url", None) or ""
+            paper_mode = getattr(settings, "alpaca_paper", None)
+            if paper_mode is None:
+                paper_mode = "paper" in base_url.lower()
+            self._stream = TradingStream(key, secret, paper=paper_mode)
         else:
             self._stream = None
 

--- a/app/models/portfolio.py
+++ b/app/models/portfolio.py
@@ -12,6 +12,7 @@ class Portfolio(Base):
     secret_key_encrypted = Column(String(255), nullable=False)
     base_url = Column(String(255), nullable=False)
     broker = Column(String(20), nullable=False, default="kraken")
+    is_paper = Column(Boolean, nullable=True)
     is_active = Column(Boolean, default=False)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
 

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -6,6 +6,7 @@ class PortfolioCreate(BaseModel):
     secret_key: str
     base_url: str
     broker: str | None = None
+    is_paper: bool | None = None
 
 
 class PortfolioResponse(BaseModel):
@@ -13,6 +14,7 @@ class PortfolioResponse(BaseModel):
     name: str
     is_active: bool
     broker: str | None = None
+    is_paper: bool | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -25,6 +25,7 @@ def create_portfolio(
     secret_key: str,
     base_url: str,
     broker: str | None = None,
+    is_paper: bool | None = None,
 ) -> Portfolio:
     f = _get_fernet()
     if broker is None:
@@ -33,12 +34,15 @@ def create_portfolio(
             broker = "alpaca"
         else:
             broker = "kraken"
+    if is_paper is None and broker == "alpaca":
+        is_paper = "paper" in base_url.lower()
     portfolio = Portfolio(
         name=name,
         api_key_encrypted=f.encrypt(api_key.encode()).decode(),
         secret_key_encrypted=f.encrypt(secret_key.encode()).decode(),
         base_url=base_url,
         broker=broker,
+        is_paper=is_paper,
         user_id=user.id,
     )
     db.add(portfolio)


### PR DESCRIPTION
## Summary
- let `Settings` track whether Alpaca is in paper mode
- store paper mode when creating a portfolio
- provide an alembic revision to add `is_paper` column
- have Alpaca REST and stream clients honor paper/live mode

## Testing
- `pip install --use-deprecated=legacy-resolver -r requirements.txt`
- `pip install httpx==0.24.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eadec8e9c83318f78a2c3e7c08daf