### PR TITLE
Implement portfolio management

### DIFF
--- a/app/api/v1/portfolios.py
+++ b/app/api/v1/portfolios.py
@@ -1,10 +1,14 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.services import portfolio_service
 from app.models.user import User
 from app.core.auth import get_current_verified_user
-from app.schemas.portfolio import PortfolioCreate, PortfolioResponse
+from app.schemas.portfolio import (
+    PortfolioCreate,
+    PortfolioResponse,
+    PortfolioUpdate,
+)
 
 router = APIRouter()
 
@@ -56,3 +60,34 @@ def activate_portfolio(
 ):
     portfolio_service.activate_portfolio(db, current_user, portfolio_id)
     return {"status": "ok"}
+
+
+@router.post("/portfolios/{portfolio_id}/deactivate")
+def deactivate_portfolio(
+    portfolio_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    portfolio_service.deactivate_portfolio(db, current_user, portfolio_id)
+    return {"status": "ok"}
+
+
+@router.put("/portfolios/{portfolio_id}", response_model=PortfolioResponse)
+def update_portfolio(
+    portfolio_id: int,
+    updates: PortfolioUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    portfolio = portfolio_service.update_portfolio(db, current_user, portfolio_id, **updates.model_dump(exclude_unset=True))
+    return portfolio
+
+
+@router.delete("/portfolios/{portfolio_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_portfolio(
+    portfolio_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    portfolio_service.delete_portfolio(db, current_user, portfolio_id)
+    return None

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -9,6 +9,15 @@ class PortfolioCreate(BaseModel):
     is_paper: bool | None = None
 
 
+class PortfolioUpdate(BaseModel):
+    name: str | None = None
+    api_key: str | None = None
+    secret_key: str | None = None
+    base_url: str | None = None
+    broker: str | None = None
+    is_paper: bool | None = None
+
+
 class PortfolioResponse(BaseModel):
     id: int
     name: str

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -114,6 +114,40 @@ export const api = {
     },
   },
 
+  // Portfolio endpoints
+  portfolios: {
+    list: async () => {
+      return authenticatedFetch(`${API_BASE_URL}/portfolios`);
+    },
+    create: async (data: any) => {
+      return authenticatedFetch(`${API_BASE_URL}/portfolios`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+    },
+    update: async (id: number, data: any) => {
+      return authenticatedFetch(`${API_BASE_URL}/portfolios/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      });
+    },
+    delete: async (id: number) => {
+      return authenticatedFetch(`${API_BASE_URL}/portfolios/${id}`, {
+        method: 'DELETE',
+      });
+    },
+    activate: async (id: number) => {
+      return authenticatedFetch(`${API_BASE_URL}/portfolios/${id}/activate`, {
+        method: 'POST',
+      });
+    },
+    deactivate: async (id: number) => {
+      return authenticatedFetch(`${API_BASE_URL}/portfolios/${id}/deactivate`, {
+        method: 'POST',
+      });
+    },
+  },
+
   // Strategy endpoints
   strategies: {
     list: async () => {


### PR DESCRIPTION
## Summary
- add portfolio update and delete endpoints
- enable deactivate portfolio backend logic
- expose portfolio API helpers in frontend
- expand portfolio controls in profile page

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687ec14884f48331bb95700fe0d9c80a