### PR TITLE
Improve error handling for account and risk endpoints

### DIFF
--- a/app/api/v1/orders.py
+++ b/app/api/v1/orders.py
@@ -84,7 +84,7 @@ async def get_account(
             "user": current_user.username,
         }
     except Exception as e:
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/positions")

--- a/app/api/v1/risk.py
+++ b/app/api/v1/risk.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models.user import User
@@ -94,7 +94,7 @@ async def get_risk_status(current_user: User = Depends(get_current_verified_user
         }
     except Exception as e:
         print(f"Error getting risk status: {e}")
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/risk/allocation-chart")
 async def get_allocation_chart_data(current_user: User = Depends(get_current_verified_user)):
@@ -134,7 +134,7 @@ async def get_allocation_chart_data(current_user: User = Depends(get_current_ver
             })
         return {"chart_data": chart_data}
     except Exception as e:
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))
 
 def _get_symbol_color(symbol: str) -> str:
     colors = {


### PR DESCRIPTION
## Summary
- Return proper HTTP errors from account endpoint instead of silent JSON error
- Raise HTTP exceptions on risk endpoints when broker data cannot be retrieved

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d8e8ab30833199d05149c105ea00