### PR TITLE
Improve error handling for account and risk endpoints

### DIFF
--- a/app/api/v1/orders.py
+++ b/app/api/v1/orders.py
@@ -1,6 +1,7 @@
 # backend/app/api/v1/orders.py
 
 from fastapi import APIRouter, Depends, HTTPException
+from alpaca.common.exceptions import APIError
 from sqlalchemy.orm import Session
 from app.integrations import broker_client
 from app.services.position_manager import position_manager
@@ -83,8 +84,13 @@ async def get_account(
             "day_trade_count": getattr(account, "day_trade_count", 0),
             "user": current_user.username,
         }
+    except APIError as e:
+        raise HTTPException(
+            status_code=e.status_code or 502,
+            detail=f"Alpaca API error: {e.message}",
+        )
     except Exception as e:
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/positions")
@@ -98,8 +104,13 @@ async def get_positions(
         )
         portfolio_summary["user"] = current_user.username
         return portfolio_summary
+    except APIError as e:
+        raise HTTPException(
+            status_code=e.status_code or 502,
+            detail=f"Alpaca API error: {e.message}",
+        )
     except Exception as e:
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/signals")

--- a/app/api/v1/risk.py
+++ b/app/api/v1/risk.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from alpaca.common.exceptions import APIError
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models.user import User
@@ -92,9 +93,15 @@ async def get_risk_status(current_user: User = Depends(get_current_verified_user
             },
             "next_positions_simulation": next_positions_simulation,
         }
+    except APIError as e:
+        print(f"Error getting risk status: {e}")
+        raise HTTPException(
+            status_code=e.status_code or 502,
+            detail=f"Alpaca API error: {e.message}",
+        )
     except Exception as e:
         print(f"Error getting risk status: {e}")
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/risk/allocation-chart")
 async def get_allocation_chart_data(current_user: User = Depends(get_current_verified_user)):
@@ -133,8 +140,13 @@ async def get_allocation_chart_data(current_user: User = Depends(get_current_ver
                 "color": "#10B981",
             })
         return {"chart_data": chart_data}
+    except APIError as e:
+        raise HTTPException(
+            status_code=e.status_code or 502,
+            detail=f"Alpaca API error: {e.message}",
+        )
     except Exception as e:
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))
 
 def _get_symbol_color(symbol: str) -> str:
     colors = {

--- a/app/services/position_manager.py
+++ b/app/services/position_manager.py
@@ -37,7 +37,7 @@ class PositionManager:
             return {pos.symbol: float(pos.qty) for pos in positions}
         except Exception as e:
             logger.error(f"Error getting positions: {e}")
-            return {}
+            raise
 
     def get_position_quantity(self, symbol):
         """Obtener cantidad específica de un símbolo"""
@@ -153,7 +153,7 @@ class PositionManager:
             }
         except Exception as e:
             logger.error(f"Error getting portfolio summary: {e}")
-            return {}
+            raise
 
 
 # Instancia global


### PR DESCRIPTION
## Summary
- Return proper HTTP errors from account endpoint instead of silent JSON error
- Raise HTTP exceptions on risk endpoints when broker data cannot be retrieved
- Propagate broker retrieval errors from position manager

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d8e8ab30833199d05149c105ea00