### PR TITLE
fix: handle Alpaca API errors gracefully

### DIFF
--- a/app/api/v1/orders.py
+++ b/app/api/v1/orders.py
@@ -87,7 +87,7 @@ async def get_account(
     except APIError as e:
         raise HTTPException(
             status_code=e.status_code or 502,
-            detail=f"Alpaca API error: {e.message}",
+            detail=f"Alpaca API error: {getattr(e, 'message', str(e))}",
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -107,7 +107,7 @@ async def get_positions(
     except APIError as e:
         raise HTTPException(
             status_code=e.status_code or 502,
-            detail=f"Alpaca API error: {e.message}",
+            detail=f"Alpaca API error: {getattr(e, 'message', str(e))}",
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/api/v1/risk.py
+++ b/app/api/v1/risk.py
@@ -97,7 +97,7 @@ async def get_risk_status(current_user: User = Depends(get_current_verified_user
         print(f"Error getting risk status: {e}")
         raise HTTPException(
             status_code=e.status_code or 502,
-            detail=f"Alpaca API error: {e.message}",
+            detail=f"Alpaca API error: {getattr(e, 'message', str(e))}",
         )
     except Exception as e:
         print(f"Error getting risk status: {e}")
@@ -143,7 +143,7 @@ async def get_allocation_chart_data(current_user: User = Depends(get_current_ver
     except APIError as e:
         raise HTTPException(
             status_code=e.status_code or 502,
-            detail=f"Alpaca API error: {e.message}",
+            detail=f"Alpaca API error: {getattr(e, 'message', str(e))}",
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- avoid AttributeError when Alpaca API errors lack a `message` property by falling back to the string representation
- apply change across account, position and risk endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896894113688331b745c9f3b6fda10a