### PR TITLE
feat: display ticker logos

### DIFF
--- a/frontend/src/components/SymbolLogo.tsx
+++ b/frontend/src/components/SymbolLogo.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+interface SymbolLogoProps {
+  symbol: string;
+  className?: string;
+  size?: number;
+}
+
+const SymbolLogo: React.FC<SymbolLogoProps> = ({ symbol, className = '', size = 32 }) => {
+  const [error, setError] = useState(false);
+  const url = `https://img.logo.dev/ticker/${symbol}?token=pk_ZIh7vOJFQWWs8N0CkI74-Q&retina=true`;
+
+  if (error) {
+    return (
+      <div
+        className={`bg-gray-100 rounded-lg flex items-center justify-center ${className}`}
+        style={{ width: size, height: size }}
+      >
+        <span className="text-xs font-bold text-gray-600">{symbol.slice(0, 2)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={url}
+      alt={`${symbol} logo`}
+      className={`rounded-lg ${className}`}
+      style={{ width: size, height: size }}
+      onError={() => setError(true)}
+    />
+  );
+};
+
+export default SymbolLogo;

--- a/frontend/src/components/active_trades_panel.tsx
+++ b/frontend/src/components/active_trades_panel.tsx
@@ -8,6 +8,7 @@ import {
   Eye,
   EyeOff,
 } from 'lucide-react';
+import SymbolLogo from './SymbolLogo';
 
 interface Trade {
   id: number;
@@ -137,6 +138,7 @@ const ActiveTradesPanel = ({ trades = [] }: ActiveTradesPanelProps) => {
             {/* Primera fila: Symbol, Side, Exchange */}
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
+                <SymbolLogo symbol={trade.symbol} size={24} />
                 <span className="font-bold text-gray-800">{trade.symbol}</span>
                 <span className={`px-2 py-1 rounded-full text-xs font-medium ${getSideBg(trade.side)} ${getSideColor(trade.side)}`}>
                   {trade.side}

--- a/frontend/src/components/recent_orders_panel.tsx
+++ b/frontend/src/components/recent_orders_panel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TrendingUp, TrendingDown, Activity } from 'lucide-react';
+import SymbolLogo from './SymbolLogo';
 
 interface Order {
   id: string;
@@ -31,7 +32,8 @@ const OrderItem: React.FC<{ order: Order }> = ({ order }) => {
     <div className="flex items-center justify-between p-4 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors duration-200">
       <div className="flex items-center">
         <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${sideBg}`}>{sideIcon}</div>
-        <div className="ml-3">
+        <SymbolLogo symbol={order.symbol} className="ml-3 mr-3" />
+        <div>
           <p className="font-semibold text-gray-900">{order.symbol}</p>
           <p className="text-sm text-gray-600">{order.qty} units</p>
         </div>

--- a/frontend/src/pages/RiskDashboard.tsx
+++ b/frontend/src/pages/RiskDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Shield, AlertTriangle, DollarSign, PieChart, Target, RefreshCw, Calculator } from 'lucide-react';
+import SymbolLogo from '../components/SymbolLogo';
 import api from '../services/api';
 
 interface RiskStatus {
@@ -204,11 +205,14 @@ const RiskDashboard: React.FC = () => {
                   key={position.symbol}
                   className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
                 >
-                  <div>
-                    <p className="font-medium">{position.symbol}</p>
-                    <p className="text-sm text-gray-600">
-                      {position.quantity} units • {position.percentage.toFixed(1)}%
-                    </p>
+                  <div className="flex items-center">
+                    <SymbolLogo symbol={position.symbol} className="mr-3" />
+                    <div>
+                      <p className="font-medium">{position.symbol}</p>
+                      <p className="text-sm text-gray-600">
+                        {position.quantity} units • {position.percentage.toFixed(1)}%
+                      </p>
+                    </div>
                   </div>
                   <div className="text-right">
                     <p className="font-medium">
@@ -245,11 +249,14 @@ const RiskDashboard: React.FC = () => {
                 }`}
               >
                 <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium">{sim.symbol}</p>
-                    <p className="text-sm text-gray-600">
-                      @ ${sim.current_price.toLocaleString()}
-                    </p>
+                  <div className="flex items-center">
+                    <SymbolLogo symbol={sim.symbol} className="mr-3" />
+                    <div>
+                      <p className="font-medium">{sim.symbol}</p>
+                      <p className="text-sm text-gray-600">
+                        @ ${sim.current_price.toLocaleString()}
+                      </p>
+                    </div>
                   </div>
                   <div className="text-right">
                     {sim.can_enter ? (

--- a/frontend/src/pages/orders.tsx
+++ b/frontend/src/pages/orders.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUp, ArrowDown, Eye, MoreHorizontal, Target, PieChart
 } from 'lucide-react';
 import Pagination from '../components/Pagination';
+import SymbolLogo from '../components/SymbolLogo';
 
 interface Order {
   id: string;
@@ -265,9 +266,7 @@ const OrdersPage: React.FC = () => {
         </td>
         <td className="px-6 py-4 whitespace-nowrap">
           <div className="flex items-center">
-            <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center mr-3">
-              <span className="text-xs font-bold text-gray-600">{order.symbol.slice(0, 2)}</span>
-            </div>
+            <SymbolLogo symbol={order.symbol} className="mr-3" />
             <span className="text-sm font-semibold text-gray-900">{order.symbol}</span>
           </div>
         </td>

--- a/frontend/src/pages/signals.tsx
+++ b/frontend/src/pages/signals.tsx
@@ -7,6 +7,7 @@ import {
   ArrowUp, ArrowDown, Calendar, Eye, Settings2
 } from 'lucide-react';
 import Pagination from '../components/Pagination';
+import SymbolLogo from '../components/SymbolLogo';
 
 interface Signal {
   id: number;
@@ -222,9 +223,7 @@ const SignalsPage: React.FC = () => {
         </td>
         <td className="px-6 py-4 whitespace-nowrap">
           <div className="flex items-center">
-            <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center mr-3">
-              <span className="text-xs font-bold text-gray-600">{signal.symbol.slice(0, 2)}</span>
-            </div>
+            <SymbolLogo symbol={signal.symbol} className="mr-3" />
             <span className="text-sm font-semibold text-gray-900">{signal.symbol}</span>
           </div>
         </td>

--- a/frontend/src/pages/trades.tsx
+++ b/frontend/src/pages/trades.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import api from '../services/api';
 import Pagination from '../components/Pagination';
+import SymbolLogo from '../components/SymbolLogo';
 
 interface Trade {
   id: number;
@@ -90,7 +91,12 @@ const TradesPage: React.FC = () => {
                 {paginatedTrades.map((trade) => (
                   <tr key={trade.id} className="border-b hover:bg-gray-50">
                     <td className="px-4 py-2">{trade.strategy_id}</td>
-                    <td className="px-4 py-2">{trade.symbol}</td>
+                    <td className="px-4 py-2">
+                      <div className="flex items-center">
+                        <SymbolLogo symbol={trade.symbol} className="mr-2" size={24} />
+                        <span>{trade.symbol}</span>
+                      </div>
+                    </td>
                     <td className="px-4 py-2">{trade.action.toUpperCase()}</td>
                     <td className="px-4 py-2">{trade.quantity}</td>
                     <td className="px-4 py-2">${trade.entry_price.toFixed(2)}</td>


### PR DESCRIPTION
## Summary
- show company logos for symbols across UI using CDN
- add reusable `SymbolLogo` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any types)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36c709e408331bd79ec9159b5c517