### PR TITLE
Wrap error icon in span to allow tooltip

### DIFF
--- a/frontend/src/pages/signals.tsx
+++ b/frontend/src/pages/signals.tsx
@@ -194,7 +194,11 @@ const SignalsPage: React.FC = () => {
         case 'processed':
           return <CheckCircle className="h-5 w-5 text-emerald-600" />;
         case 'error':
-          return <XCircle className="h-5 w-5 text-red-600" title={signal.error_message} />;
+          return (
+            <span title={signal.error_message}>
+              <XCircle className="h-5 w-5 text-red-600" />
+            </span>
+          );
         case 'pending':
           return <Clock className="h-5 w-5 text-yellow-600" />;
         default:


### PR DESCRIPTION
## Summary
- Wrap error status icon in `<span>` so tooltip can show without TypeScript complaint

## Testing
- `npm run lint` (fails: Unexpected any)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a460c848cc8331825a64d11d234fe8