### PR TITLE
Add extended-hours flag for Alpaca orders

### DIFF
--- a/tests/test_alpaca_client.py
+++ b/tests/test_alpaca_client.py
@@ -4,6 +4,24 @@ os.environ.setdefault('SECRET_KEY', 'secret')
 from app.integrations.alpaca.client import AlpacaClient
 
 
+def test_submit_order_uses_extended_hours_outside_regular(monkeypatch):
+    client = AlpacaClient()
+
+    class DummyTrading:
+        def submit_order(self, order):
+            self.order = order
+            return type("O", (), {"id": "1", "status": "accepted"})()
+
+    dummy = DummyTrading()
+    monkeypatch.setattr(client, "_trading", dummy)
+    monkeypatch.setattr(
+        "app.integrations.alpaca.client._in_regular_trading_hours", lambda: False
+    )
+
+    client.submit_order("AAPL", 1, "buy")
+    assert dummy.order.extended_hours is True
+
+
 def test_get_position(monkeypatch):
     client = AlpacaClient()
 


### PR DESCRIPTION
## Summary
- add helper to detect regular trading hours in Alpaca client
- automatically enable `extended_hours` on orders placed outside regular hours
- test that extended hours parameter is set when required

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a51b581f5c8331aa0b3c7459928b35