### PR TITLE
Align application timestamps to US Eastern

### DIFF
--- a/app/api/v1/orders.py
+++ b/app/api/v1/orders.py
@@ -10,6 +10,7 @@ from app.models.signal import Signal
 from app.models.user import User
 from app.core.auth import get_current_verified_user, get_admin_user
 from app.services import portfolio_service
+from app.utils.time import to_eastern
 
 router = APIRouter()
 
@@ -145,7 +146,7 @@ async def get_signals(
             "quantity": signal.quantity,
             "status": signal.status,
             "error_message": signal.error_message,
-            "timestamp": signal.timestamp.isoformat(),
+            "timestamp": to_eastern(signal.timestamp).isoformat(),
             "strategy_id": signal.strategy_id,
             "source": "tradingview"
         }
@@ -170,7 +171,7 @@ async def get_all_signals(
             "strategy_id": signal.strategy_id,
             "quantity": signal.quantity,
             "status": signal.status,
-            "timestamp": signal.timestamp.isoformat(),
+            "timestamp": to_eastern(signal.timestamp).isoformat(),
             "user_id": signal.user_id,
             "username": signal.user.username if signal.user else "Unknown"
         }

--- a/app/api/v1/webhooks.py
+++ b/app/api/v1/webhooks.py
@@ -13,6 +13,7 @@ from app.core.auth import get_current_verified_user
 from app.config import settings
 from app.websockets import ws_manager
 from app.services import portfolio_service
+from app.utils.time import to_eastern
 import asyncio
 import json
 import logging
@@ -75,7 +76,7 @@ async def receive_tradingview_webhook(
             "quantity": signal.quantity,
             "status": signal.status,
             "strategy_id": signal.strategy_id,
-            "timestamp": signal.timestamp.isoformat(),
+            "timestamp": to_eastern(signal.timestamp).isoformat(),
         }
         asyncio.create_task(
             ws_manager.broadcast(json.dumps({"event": "new_signal", "payload": signal_data}))
@@ -88,7 +89,7 @@ async def receive_tradingview_webhook(
             "quantity": signal.quantity,
             "status": signal.status,
             "strategy_id": signal.strategy_id,
-            "timestamp": signal.timestamp.isoformat(),
+            "timestamp": to_eastern(signal.timestamp).isoformat(),
         }
         asyncio.create_task(
             ws_manager.broadcast(json.dumps({"event": "new_signal", "payload": signal_data}))
@@ -159,7 +160,7 @@ async def get_signals(
             "quantity": signal.quantity,
             "status": signal.status,
             "error_message": signal.error_message,
-            "timestamp": signal.timestamp,
+            "timestamp": to_eastern(signal.timestamp),
             "reason": signal.reason,
             "confidence": signal.confidence,
             "tv_timestamp": signal.tv_timestamp,

--- a/app/integrations/alpaca/client.py
+++ b/app/integrations/alpaca/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from datetime import datetime, time
-from zoneinfo import ZoneInfo
+from app.utils.time import EASTERN_TZ, now_eastern
 
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import GetOrdersRequest
@@ -19,8 +19,7 @@ from app.config import settings
 
 
 def _in_regular_trading_hours(now: datetime | None = None) -> bool:
-    tz = ZoneInfo("America/New_York")
-    current = now.astimezone(tz) if now else datetime.now(tz)
+    current = now.astimezone(EASTERN_TZ) if now else now_eastern()
     start = time(9, 30)
     end = time(16, 0)
     return current.weekday() < 5 and start <= current.time() < end

--- a/app/models/signal.py
+++ b/app/models/signal.py
@@ -2,8 +2,8 @@
 
 from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, Text, ForeignKey
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
 from app.database import Base
+from app.utils.time import now_eastern
 
 
 class Signal(Base):
@@ -16,7 +16,7 @@ class Signal(Base):
     quantity = Column(Float, nullable=True)  # ✅ CHANGED: Float instead of Integer to support decimals
     price = Column(Float, nullable=True)
     source = Column(String(50), default="tradingview")
-    timestamp = Column(DateTime, server_default=func.now())
+    timestamp = Column(DateTime(timezone=True), default=now_eastern)
     processed = Column(Boolean, default=False)
     status = Column(String(20), default="pending")  # pending, processed, error
     error_message = Column(Text, nullable=True)

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,6 +1,7 @@
 # backend/app/services/auth_service.py
 
-from datetime import datetime, timedelta
+from datetime import timedelta
+from app.utils.time import now_eastern
 from typing import Optional
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -33,9 +34,9 @@ class AuthService:
         to_encode = data.copy()
 
         if expires_delta:
-            expire = datetime.utcnow() + expires_delta
+            expire = now_eastern() + expires_delta
         else:
-            expire = datetime.utcnow() + timedelta(minutes=self.access_token_expire_minutes)
+            expire = now_eastern() + timedelta(minutes=self.access_token_expire_minutes)
 
         to_encode.update({"exp": expire})
         encoded_jwt = jwt.encode(to_encode, self.secret_key, algorithm=self.algorithm)
@@ -103,7 +104,7 @@ class AuthService:
 
     def update_last_login(self, db: Session, user: User):
         """Actualizar último login"""
-        user.last_login = datetime.utcnow()
+        user.last_login = now_eastern()
         db.commit()
 
     def generate_reset_token(self, db: Session, email: str) -> Optional[str]:
@@ -113,7 +114,7 @@ class AuthService:
             return None
 
         reset_token = user.generate_reset_token()
-        user.reset_token_expires = datetime.utcnow() + timedelta(hours=1)  # 1 hora
+        user.reset_token_expires = now_eastern() + timedelta(hours=1)  # 1 hora
 
         db.commit()
         return reset_token
@@ -125,7 +126,7 @@ class AuthService:
         if not user or not user.reset_token_expires:
             return False
 
-        if datetime.utcnow() > user.reset_token_expires:
+        if now_eastern() > user.reset_token_expires:
             return False
 
         # Actualizar password

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+EASTERN_TZ = ZoneInfo("America/New_York")
+
+
+def now_eastern() -> datetime:
+    """Return current time in US Eastern timezone."""
+    return datetime.now(EASTERN_TZ)
+
+
+def to_eastern(dt: datetime) -> datetime:
+    """Convert a datetime to US Eastern timezone.
+
+    Naive datetimes are assumed to be in UTC.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+    return dt.astimezone(EASTERN_TZ)


### PR DESCRIPTION
## Summary
- centralize US/Eastern timezone utilities
- store and emit signal timestamps in Eastern time
- generate auth tokens and timestamps using Eastern time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a51d7b6c048331a17b635749c560ba