### PR TITLE
Ensure consistent US Eastern timezone across app

### DIFF
--- a/app/models/strategy.py
+++ b/app/models/strategy.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, DateTime
-from sqlalchemy.sql import func
+from app.utils.time import now_eastern
 
 from app.database import Base
 
@@ -11,8 +11,8 @@ class Strategy(Base):
 
     name = Column(String(100), unique=True, nullable=False, index=True)
     description = Column(String(255), nullable=True)
-    created_at = Column(DateTime, server_default=func.now())
-    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    created_at = Column(DateTime(timezone=True), default=now_eastern)
+    updated_at = Column(DateTime(timezone=True), default=now_eastern, onupdate=now_eastern)
 
     def __repr__(self):
         return f"<Strategy({self.id}, {self.name})>"

--- a/app/models/strategy_position.py
+++ b/app/models/strategy_position.py
@@ -1,7 +1,7 @@
 # backend/app/models/strategy_position.py
 
 from sqlalchemy import Column, Integer, String, Float, DateTime, UniqueConstraint
-from sqlalchemy.sql import func
+from app.utils.time import now_eastern
 from app.database import Base
 
 
@@ -14,8 +14,8 @@ class StrategyPosition(Base):
     quantity = Column(Float, nullable=False, default=0.0)  # Puede ser decimal para crypto
     avg_price = Column(Float, nullable=True)  # Precio promedio de compra
     total_invested = Column(Float, nullable=False, default=0.0)  # Total invertido
-    created_at = Column(DateTime, server_default=func.now())
-    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    created_at = Column(DateTime(timezone=True), default=now_eastern)
+    updated_at = Column(DateTime(timezone=True), default=now_eastern, onupdate=now_eastern)
 
     # Constraint para evitar duplicados: una estrategia solo puede tener una posición por símbolo
     __table_args__ = (

--- a/app/models/trades.py
+++ b/app/models/trades.py
@@ -1,8 +1,8 @@
 # backend/app/models/trade.py
 
 from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey
-from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
+from app.utils.time import now_eastern
 from app.database import Base
 
 
@@ -17,8 +17,8 @@ class Trade(Base):
     entry_price = Column(Float)
     exit_price = Column(Float, nullable=True)
     status = Column(String(10), default="open")  # open, closed
-    opened_at = Column(DateTime, default=func.now())
-    closed_at = Column(DateTime, nullable=True)
+    opened_at = Column(DateTime(timezone=True), default=now_eastern)
+    closed_at = Column(DateTime(timezone=True), nullable=True)
     pnl = Column(Float, nullable=True)
 
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,7 +1,7 @@
 # backend/app/models/user.py
 
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text
-from sqlalchemy.sql import func
+from app.utils.time import now_eastern
 from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy.orm import relationship
 from app.database import Base
@@ -31,12 +31,12 @@ class User(Base):
     # Tokens
     verification_token = Column(String(255), nullable=True)
     reset_token = Column(String(255), nullable=True)
-    reset_token_expires = Column(DateTime, nullable=True)
+    reset_token_expires = Column(DateTime(timezone=True), nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, server_default=func.now())
-    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
-    last_login = Column(DateTime, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=now_eastern)
+    updated_at = Column(DateTime(timezone=True), default=now_eastern, onupdate=now_eastern)
+    last_login = Column(DateTime(timezone=True), nullable=True)
 
     def set_password(self, password: str):
         """Hashear password"""

--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -8,7 +8,7 @@ from app.services.strategy_position_manager import StrategyPositionManager
 from app.database import get_db
 import logging
 from app.models.trades import Trade
-from sqlalchemy.sql import func
+from app.utils.time import now_eastern
 from app.websockets import ws_manager
 import asyncio
 import json
@@ -320,7 +320,7 @@ class OrderExecutor:
         ).order_by(Trade.opened_at.desc()).all()
 
         if open_trades:
-            now = func.now()
+            now = now_eastern()
             for trade in open_trades:
                 trade.exit_price = current_price
                 trade.closed_at = now

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './utils/timezone'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/utils/timezone.ts
+++ b/frontend/src/utils/timezone.ts
@@ -1,0 +1,22 @@
+const DEFAULT_LOCALE = 'en-US';
+const DEFAULT_TZ = 'America/New_York';
+
+const { toLocaleString, toLocaleDateString, toLocaleTimeString } = Date.prototype as unknown as {
+  toLocaleString: typeof Date.prototype.toLocaleString;
+  toLocaleDateString: typeof Date.prototype.toLocaleDateString;
+  toLocaleTimeString: typeof Date.prototype.toLocaleTimeString;
+};
+
+Date.prototype.toLocaleString = function (locale?: string | string[], options?: Intl.DateTimeFormatOptions) {
+  return toLocaleString.call(this, locale ?? DEFAULT_LOCALE, { timeZone: DEFAULT_TZ, ...(options ?? {}) });
+};
+
+Date.prototype.toLocaleDateString = function (locale?: string | string[], options?: Intl.DateTimeFormatOptions) {
+  return toLocaleDateString.call(this, locale ?? DEFAULT_LOCALE, { timeZone: DEFAULT_TZ, ...(options ?? {}) });
+};
+
+Date.prototype.toLocaleTimeString = function (locale?: string | string[], options?: Intl.DateTimeFormatOptions) {
+  return toLocaleTimeString.call(this, locale ?? DEFAULT_LOCALE, { timeZone: DEFAULT_TZ, ...(options ?? {}) });
+};
+
+export {};

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -1,9 +1,9 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from datetime import datetime
 from app.database import Base
 from app.models.trades import Trade
 from app.services.trade_service import TradeService
+from app.utils.time import now_eastern
 
 
 def _setup_db():
@@ -15,7 +15,7 @@ def _setup_db():
 
 def test_equity_curve_filters_by_strategy():
     db = _setup_db()
-    now = datetime.utcnow()
+    now = now_eastern()
     trades = [
         Trade(strategy_id="A", symbol="AAPL", action="buy", quantity=1, entry_price=100,
               status="closed", closed_at=now, pnl=10, user_id=1, portfolio_id=1),

--- a/tests/test_trade_metrics.py
+++ b/tests/test_trade_metrics.py
@@ -1,8 +1,8 @@
 import math
 import os
-from datetime import datetime
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from app.utils.time import now_eastern
 
 os.environ.setdefault('SECRET_KEY', 'secret')
 
@@ -16,7 +16,7 @@ def _setup_trades(pnls):
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     session = Session()
-    now = datetime.utcnow()
+    now = now_eastern()
     for pnl in pnls:
         trade = Trade(
             strategy_id="s",


### PR DESCRIPTION
## Summary
- standardize datetime fields to US Eastern timezone
- close trades and tokens using timezone-aware timestamps
- force frontend date formatting to America/New_York

## Testing
- `pytest`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5b94e48a48331ba334fb04663993d