### PR TITLE
Ensure trades use Eastern timezone

### DIFF
--- a/app/schemas/trades.py
+++ b/app/schemas/trades.py
@@ -1,8 +1,10 @@
 # backend/app/schemas/trade.py
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_serializer
 from typing import Optional
 from datetime import datetime
+
+from app.utils.time import to_eastern
 
 
 class TradeSchema(BaseModel):
@@ -22,9 +24,19 @@ class TradeSchema(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+    @field_serializer('opened_at', 'closed_at', when_used='json')
+    def serialize_dt(self, dt: datetime | None) -> str | None:
+        if dt is None:
+            return None
+        return to_eastern(dt).isoformat()
+
 
 class EquityPointSchema(BaseModel):
     strategy_id: Optional[str] = None
     timestamp: datetime
     equity: float
+
+    @field_serializer('timestamp', when_used='json')
+    def serialize_ts(self, dt: datetime) -> str:
+        return to_eastern(dt).isoformat()
 


### PR DESCRIPTION
## Summary
- serialize trade and equity point timestamps in US Eastern timezone to ensure consistent display across dashboard and trades page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5bcf356b883318c241f10f31cbe8a