### PR TITLE
Translate UI templates to English

### DIFF
--- a/frontend/src/components/active_trades_panel.tsx
+++ b/frontend/src/components/active_trades_panel.tsx
@@ -151,23 +151,23 @@ const ActiveTradesPanel = ({ trades = [] }: ActiveTradesPanelProps) => {
               </div>
             </div>
 
-            {/* Segunda fila: Tamaño y Hora */}
+            {/* Second row: Size and Time */}
             <div className="flex items-center justify-between mb-2 text-sm text-gray-600">
-              <span>Tamaño: {trade.size}</span>
+              <span>Size: {trade.size}</span>
               <div className="flex items-center gap-1">
                 <Clock className="w-3 h-3" />
                 <span>{trade.openTime}</span>
               </div>
             </div>
 
-            {/* Tercera fila: Precios */}
+            {/* Third row: Prices */}
             <div className="grid grid-cols-2 gap-2 text-xs mb-2">
               <div>
-                <span className="text-gray-500">Entrada: </span>
+                <span className="text-gray-500">Entry: </span>
                 <span className="font-medium">${formatPrice(trade.entryPrice)}</span>
               </div>
               <div>
-                <span className="text-gray-500">Actual: </span>
+                <span className="text-gray-500">Current: </span>
                 <span className="font-medium">${formatPrice(trade.currentPrice)}</span>
               </div>
             </div>
@@ -198,11 +198,11 @@ const ActiveTradesPanel = ({ trades = [] }: ActiveTradesPanelProps) => {
         )}
       </div>
 
-      {/* Footer con estadísticas */}
+      {/* Footer with stats */}
       <div className="mt-4 pt-3 border-t border-gray-200">
         <div className="flex justify-between text-xs text-gray-600">
-          <span>{profitableTrades}/{processedTrades.length} rentables</span>
-          <span>Última actualización: hace 2m</span>
+          <span>{profitableTrades}/{processedTrades.length} profitable</span>
+          <span>Last updated: 2m ago</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/equity_curve_pro.tsx
+++ b/frontend/src/components/equity_curve_pro.tsx
@@ -54,7 +54,7 @@ const EquityCurvePro: React.FC<EquityCurveProProps> = ({ data = [] as EquityPoin
         }`}
       >
         <div className="flex items-center justify-center h-64 text-gray-500">
-          Sin datos disponibles
+          No data available
         </div>
       </div>
     );
@@ -125,7 +125,7 @@ const EquityCurvePro: React.FC<EquityCurveProProps> = ({ data = [] as EquityPoin
           </div>
           <div>
             <h3 className="text-xl font-bold text-gray-800">Equity Curve</h3>
-            <p className="text-sm text-gray-500">Rendimiento de la cuenta en tiempo real</p>
+            <p className="text-sm text-gray-500">Real-time account performance</p>
           </div>
         </div>
         
@@ -192,7 +192,7 @@ const EquityCurvePro: React.FC<EquityCurveProProps> = ({ data = [] as EquityPoin
         <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-4">
           <div className="flex items-center gap-2 mb-2">
             <DollarSign className="w-4 h-4 text-green-600" />
-            <span className="text-sm font-medium text-green-800">Equity Actual</span>
+            <span className="text-sm font-medium text-green-800">Current Equity</span>
           </div>
           <div className="text-2xl font-bold text-green-700">
             ${currentEquity.toLocaleString()}
@@ -206,14 +206,14 @@ const EquityCurvePro: React.FC<EquityCurveProProps> = ({ data = [] as EquityPoin
           <div className="flex items-center gap-2 mb-2">
             <TrendingUp className={`w-4 h-4 ${totalReturn >= 0 ? 'text-blue-600' : 'text-red-600'}`} />
             <span className={`text-sm font-medium ${totalReturn >= 0 ? 'text-blue-800' : 'text-red-800'}`}>
-              Retorno Total
+              Total Return
             </span>
           </div>
           <div className={`text-2xl font-bold ${totalReturn >= 0 ? 'text-blue-700' : 'text-red-700'}`}>
             {totalReturn >= 0 ? '+' : ''}{totalReturn.toFixed(2)}%
           </div>
           <div className={`text-sm ${totalReturn >= 0 ? 'text-blue-600' : 'text-red-600'}`}>
-            Desde inicio
+            Since start
           </div>
         </div>
 
@@ -226,7 +226,7 @@ const EquityCurvePro: React.FC<EquityCurveProProps> = ({ data = [] as EquityPoin
             {maxDrawdown.toFixed(2)}%
           </div>
           <div className="text-sm text-purple-600">
-            Pérdida máxima
+            Maximum loss
           </div>
         </div>
 
@@ -276,11 +276,11 @@ const EquityCurvePro: React.FC<EquityCurveProProps> = ({ data = [] as EquityPoin
             <Tooltip content={<CustomTooltip />} />
             
             {/* Línea de equity inicial */}
-            <ReferenceLine 
-              y={initialEquity} 
-              stroke="#6B7280" 
-              strokeDasharray="5 5" 
-              label={{ value: "Capital Inicial", position: "left" }}
+            <ReferenceLine
+              y={initialEquity}
+              stroke="#6B7280"
+              strokeDasharray="5 5"
+              label={{ value: "Initial Capital", position: "left" }}
             />
             
             {/* Área de equity */}
@@ -336,7 +336,7 @@ const EquityCurvePro: React.FC<EquityCurveProProps> = ({ data = [] as EquityPoin
             <div className="text-lg font-bold text-green-600">68.5%</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Volatilidad</div>
+            <div className="text-sm text-gray-500">Volatility</div>
             <div className="text-lg font-bold text-blue-600">12.3%</div>
           </div>
           <div>

--- a/frontend/src/components/winrate_speedometer.tsx
+++ b/frontend/src/components/winrate_speedometer.tsx
@@ -102,7 +102,7 @@ const WinRateSpeedometer: React.FC<WinRateProps> = ({ winRate = 68.5, totalTrade
           <BarChart3 className="w-6 h-6 text-gray-600" />
           <h3 className="text-lg font-semibold text-gray-800">Win Rate</h3>
         </div>
-        <p className="text-sm text-gray-500">Rendimiento General</p>
+        <p className="text-sm text-gray-500">Overall Performance</p>
       </div>
 
       {/* Speedometer */}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -502,7 +502,7 @@ const TradingDashboard: React.FC = () => {
       <div className="mb-8">
         {equityCurve.length === 0 ? (
           <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 text-center text-gray-500">
-            Sin datos de equity disponibles
+            No equity data available
           </div>
         ) : (
           <EquityCurvePro


### PR DESCRIPTION
## Summary
- Replace Spanish strings with English across dashboard, trade panels, and equity curve components
- Standardize win rate header text to English

## Testing
- `pytest`
- `npm run lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cdd5236883319c581935fa6e23d9