### PR TITLE
fix: detect crypto symbols when fetching prices

### DIFF
--- a/app/integrations/alpaca/client.py
+++ b/app/integrations/alpaca/client.py
@@ -120,6 +120,19 @@ class AlpacaClient:
     def submit_crypto_order(self, symbol, qty, side, order_type="market"):
         return self.submit_order(symbol, qty, side, order_type)
 
+    def is_crypto_symbol(self, symbol: str) -> bool:
+        """Return True if ``symbol`` represents a crypto asset.
+
+        Alpaca identifies crypto either with a slash (``BTC/USD``) or by
+        concatenating the base and quote (``BTCUSD``). We use a simple heuristic
+        to detect these formats so the service can choose the appropriate quote
+        endpoint.
+        """
+        symbol = (symbol or "").upper()
+        if "/" in symbol:
+            return True
+        return symbol.endswith(("USD", "USDT", "USDC"))
+
     # --- Market data ----------------------------------------------------------
     def get_latest_quote(self, symbol: str):
         if not self._stock_data:


### PR DESCRIPTION
## Summary
- add heuristic `is_crypto_symbol` to Alpaca client so crypto trades fetch proper quotes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5cffe1cc483318f98b576152c8b05