### PR TITLE
Use Alpaca unrealized PnL in risk status

### DIFF
--- a/app/integrations/alpaca/client.py
+++ b/app/integrations/alpaca/client.py
@@ -73,17 +73,40 @@ class AlpacaClient:
         )
 
     def get_positions(self):
+        """Get all positions with complete information including unrealized PnL"""
         if not self._trading:
             return []
         positions = self._trading.get_all_positions()
-        return [SimpleNamespace(symbol=p.symbol, qty=float(p.qty)) for p in positions]
+        return [
+            SimpleNamespace(
+                symbol=p.symbol,
+                qty=float(p.qty),
+                market_value=float(getattr(p, "market_value", 0) or 0),
+                unrealized_pl=float(getattr(p, "unrealized_pl", 0) or 0),
+                unrealized_plpc=float(getattr(p, "unrealized_plpc", 0) or 0),
+                cost_basis=float(getattr(p, "cost_basis", 0) or 0),
+                avg_entry_price=float(getattr(p, "avg_entry_price", 0) or 0),
+                current_price=float(getattr(p, "current_price", 0) or 0),
+            )
+            for p in positions
+        ]
 
     def get_position(self, symbol: str):
+        """Get single position with complete information"""
         if not self._trading:
             return None
         try:
             p = self._trading.get_open_position(symbol)
-            return SimpleNamespace(symbol=p.symbol, qty=float(p.qty))
+            return SimpleNamespace(
+                symbol=p.symbol,
+                qty=float(p.qty),
+                market_value=float(getattr(p, "market_value", 0) or 0),
+                unrealized_pl=float(getattr(p, "unrealized_pl", 0) or 0),
+                unrealized_plpc=float(getattr(p, "unrealized_plpc", 0) or 0),
+                cost_basis=float(getattr(p, "cost_basis", 0) or 0),
+                avg_entry_price=float(getattr(p, "avg_entry_price", 0) or 0),
+                current_price=float(getattr(p, "current_price", 0) or 0),
+            )
         except Exception:
             return None
 

--- a/app/services/position_manager.py
+++ b/app/services/position_manager.py
@@ -39,6 +39,28 @@ class PositionManager:
             logger.error(f"Error getting positions: {e}")
             raise
 
+    def get_detailed_positions(self):
+        """Obtener posiciones con información detallada para mostrar en UI"""
+        try:
+            positions = self.broker.get_positions()
+            detailed_positions = []
+            for pos in positions:
+                if abs(pos.qty) >= 0.001:
+                    detailed_positions.append({
+                        'symbol': pos.symbol,
+                        'quantity': float(pos.qty),
+                        'market_value': getattr(pos, 'market_value', 0.0),
+                        'unrealized_pl': getattr(pos, 'unrealized_pl', 0.0),
+                        'unrealized_plpc': getattr(pos, 'unrealized_plpc', 0.0),
+                        'cost_basis': getattr(pos, 'cost_basis', 0.0),
+                        'avg_entry_price': getattr(pos, 'avg_entry_price', 0.0),
+                        'current_price': getattr(pos, 'current_price', 0.0)
+                    })
+            return detailed_positions
+        except Exception as e:
+            logger.error(f"Error getting detailed positions: {e}")
+            return []
+
     def get_position_quantity(self, symbol):
         """Obtener cantidad específica de un símbolo"""
         try:

--- a/tests/test_risk_route.py
+++ b/tests/test_risk_route.py
@@ -6,7 +6,32 @@ from app.api.v1 import risk
 
 
 def test_market_value_calculation(monkeypatch):
-    monkeypatch.setattr(risk.position_manager, "get_current_positions", lambda: {"AAPL": 5, "USD": 25.31})
+    monkeypatch.setattr(
+        risk.position_manager,
+        "get_detailed_positions",
+        lambda: [
+            {
+                'symbol': 'AAPL',
+                'quantity': 5,
+                'market_value': 5 * 180.0,
+                'unrealized_pl': 0.0,
+                'unrealized_plpc': 0.0,
+                'cost_basis': 0.0,
+                'avg_entry_price': 170.0,
+                'current_price': 180.0,
+            },
+            {
+                'symbol': 'USD',
+                'quantity': 25.31,
+                'market_value': 25.31,
+                'unrealized_pl': 0.0,
+                'unrealized_plpc': 0.0,
+                'cost_basis': 0.0,
+                'avg_entry_price': 1.0,
+                'current_price': 1.0,
+            }
+        ]
+    )
     monkeypatch.setattr(risk.risk_manager, "get_allocation_info", lambda buying_power: {})
     monkeypatch.setattr(risk.risk_manager, "calculate_optimal_position_size", lambda **k: 0)
     monkeypatch.setattr(risk.risk_manager, "get_symbol_minimum", lambda s: 0)


### PR DESCRIPTION
## Summary
- expose full Alpaca position details including unrealized PnL
- provide detailed positions via PositionManager for UI
- compute risk endpoint position details and total unrealized PnL using Alpaca data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5da09e1d08331aebd3556b6065a07