### PR TITLE
fix: handle optional debug info in RiskDashboard

### DIFF
--- a/frontend/src/pages/RiskDashboard.tsx
+++ b/frontend/src/pages/RiskDashboard.tsx
@@ -145,7 +145,7 @@ const RiskDashboard: React.FC = () => {
       </div>
 
       {/* Debug info without interrupting dashboard */}
-      {riskStatus.debug_info && <DebugInfo debugInfo={riskStatus.debug_info} />}
+      {!!riskStatus.debug_info && <DebugInfo debugInfo={riskStatus.debug_info} />}
 
       {/* Top Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">


### PR DESCRIPTION
## Summary
- ensure optional debug info casts to boolean before rendering

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a614122d508331a706087fdf9a6439