### PR TITLE
Fix PnL calculations and add realtime portfolio endpoint

### DIFF
--- a/app/api/v1/portfolio.py
+++ b/app/api/v1/portfolio.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException
+from app.models.user import User
+from app.core.auth import get_current_verified_user
+
+router = APIRouter()
+
+@router.get("/portfolio/realtime")
+async def get_realtime_portfolio(current_user: User = Depends(get_current_verified_user)):
+    """Get portfolio with real-time PnL from positions"""
+    try:
+        from app.integrations import broker_client
+        from app.services.position_manager import position_manager
+
+        # Obtener datos de cuenta base
+        account = broker_client.get_account()
+        buying_power = float(getattr(account, "buying_power", 0))
+        portfolio_value = float(getattr(account, "portfolio_value", 0))
+        cash = float(getattr(account, "cash", 0))
+
+        # Obtener posiciones con PnL real
+        detailed_positions = position_manager.get_detailed_positions()
+
+        # Calcular PnL total no realizado
+        total_unrealized_pl = sum(pos.get('unrealized_pl', 0.0) for pos in detailed_positions)
+
+        return {
+            "account": {
+                "buying_power": str(buying_power),
+                "portfolio_value": str(portfolio_value),
+                "cash": str(cash),
+                "unrealized_pl": total_unrealized_pl,
+                "day_change": total_unrealized_pl,
+                "day_change_percent": (total_unrealized_pl / (portfolio_value - total_unrealized_pl) * 100) if portfolio_value > total_unrealized_pl else 0
+            },
+            "positions": detailed_positions
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.api.v1.portfolios import router as portfolios_router
 from app.api.v1.streaming import router as streaming_router
 from app.api.v1 import risk
 from app.api.ws import router as ws_router
+from app.api.v1.portfolio import router as portfolio_router
 from app.database import SessionLocal
 from app.services import portfolio_service
 from app.integrations import refresh_broker_client
@@ -37,6 +38,7 @@ app.include_router(auth_router, prefix="/api/v1/auth", tags=["authentication"])
 app.include_router(portfolios_router, prefix="/api/v1", tags=["portfolios"])
 app.include_router(streaming_router, prefix="/api/v1", tags=["streaming"])
 app.include_router(risk.router, prefix="/api/v1", tags=["risk"])
+app.include_router(portfolio_router, prefix="/api/v1", tags=["portfolio"])
 app.include_router(ws_router)
 
 

--- a/frontend/src/components/active_trades_panel.tsx
+++ b/frontend/src/components/active_trades_panel.tsx
@@ -49,10 +49,14 @@ const ActiveTradesPanel = ({ trades = [] }: ActiveTradesPanelProps) => {
   const DEFAULT_EXCHANGE = import.meta.env.VITE_DEFAULT_EXCHANGE || 'Alpaca';
 
   const processedTrades: ProcessedTrade[] = trades.map((t) => {
+    // El PnL ya viene calculado correctamente desde la base de datos
     const pnl = t.pnl ?? 0;
-    const currentPrice = t.entry_price + pnl / t.quantity;
-    const pnlPercent = t.quantity ? (pnl / (t.entry_price * t.quantity)) * 100 : 0;
+
+    // Calcular el precio actual basado en el PnL si no está disponible
+    const currentPrice = t.quantity !== 0 ? t.entry_price + pnl / t.quantity : t.entry_price;
+    const pnlPercent = (t.entry_price * t.quantity) !== 0 ? (pnl / (t.entry_price * t.quantity)) * 100 : 0;
     const side: Side = t.action.toLowerCase() === 'buy' ? 'LONG' : 'SHORT';
+
     return {
       id: t.id,
       symbol: t.symbol,


### PR DESCRIPTION
## Summary
- use stored PnL for active trades
- add real-time portfolio endpoint and surface unrealized PnL in dashboard

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a6167a15688331b2f96d34c85abb48