### PR TITLE
chore(frontend): remove unused dashboard icons

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -14,9 +14,6 @@ import {
   ArrowUpRight,
   ArrowDownRight,
   BarChart3,
-  PieChart,
-  Calendar,
-  Users,
   Eye,
   EyeOff
 } from 'lucide-react';


### PR DESCRIPTION
## Summary
- remove unused PieChart, Calendar, and Users imports from dashboard page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors in unrelated files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8f24fd42c833184fc9d5a1ed5e0cf