### PR TITLE
Align dashboard widgets and signal visuals

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -357,7 +357,7 @@ const Dashboard: React.FC = () => {
                 </div>
               </div>
               <div className="p-4">
-                <div className="space-y-2 max-h-96 overflow-y-auto">
+                <div className="space-y-1 max-h-96 overflow-y-auto">
                   {positions.length === 0 ? (
                     <div className="text-center py-12">
                       <BarChart3 className="w-12 h-12 text-slate-300 mx-auto mb-4" />
@@ -410,7 +410,7 @@ const Dashboard: React.FC = () => {
                 </div>
               </div>
               <div className="p-4">
-                <div className="space-y-2 max-h-96 overflow-y-auto">
+                <div className="space-y-1 max-h-96 overflow-y-auto">
                   {signals.length === 0 ? (
                     <div className="text-center py-12">
                       <Zap className="w-12 h-12 text-slate-300 mx-auto mb-4" />
@@ -422,6 +422,7 @@ const Dashboard: React.FC = () => {
                       <div key={signal.id} className="group flex items-center justify-between p-4 hover:bg-slate-50 rounded-xl transition-all duration-200">
                         <div className="flex items-center space-x-4">
                           {getSignalStatusIcon(signal.status)}
+                          <SymbolLogo symbol={signal.symbol} size={32} />
                           <div>
                             <div className="flex items-center space-x-2">
                               <p className="font-bold text-slate-900">{signal.symbol}</p>


### PR DESCRIPTION
## Summary
- Ensure dashboard positions and signals widgets share max height and spacing
- Show company logos beside signal status icons
- Verify action and status badges use consistent green/red/yellow colors

## Testing
- `npm run lint` *(fails: 23 errors, 4 warnings)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9b64fb7f48331a6c4f2becbc39c75