### PR TITLE
fix: adjust signal widget badge colors

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -3,13 +3,12 @@ import {
   TrendingUp,
   TrendingDown,
   DollarSign,
-  Target, 
-  Activity, 
-  Clock, 
-  CheckCircle, 
-  XCircle, 
-  AlertTriangle, 
-  Zap, 
+  Target,
+  Activity,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Zap,
   Brain,
   ArrowUpRight,
   ArrowDownRight,
@@ -55,7 +54,7 @@ interface Signal {
   confidence: number;
   strategy_id: string;
   created_at: string;
-  status: 'pending' | 'executed' | 'rejected';
+  status: 'pending' | 'processed' | 'error';
 }
 
 interface StrategyMetrics {
@@ -215,10 +214,14 @@ const Dashboard: React.FC = () => {
 
   const getSignalStatusIcon = (status: string) => {
     switch (status) {
-      case 'executed': return <CheckCircle className="w-3 h-3 text-emerald-500" />;
-      case 'pending': return <Clock className="w-3 h-3 text-amber-500" />;
-      case 'rejected': return <XCircle className="w-3 h-3 text-rose-500" />;
-      default: return <AlertTriangle className="w-3 h-3 text-slate-400" />;
+      case 'processed':
+        return <CheckCircle className="w-3 h-3 text-emerald-500" />;
+      case 'pending':
+        return <Clock className="w-3 h-3 text-amber-500" />;
+      case 'error':
+        return <XCircle className="w-3 h-3 text-rose-500" />;
+      default:
+        return null;
     }
   };
 
@@ -442,7 +445,7 @@ const Dashboard: React.FC = () => {
                         <div className="text-right">
                           <p className="text-xs text-slate-400">{formatTime(signal.created_at)}</p>
                           <div className={`text-xs px-2 py-1 rounded-full font-medium mt-1 ${
-                            signal.status === 'executed' ? 'bg-emerald-100 text-emerald-800' :
+                            signal.status === 'processed' ? 'bg-emerald-100 text-emerald-800' :
                             signal.status === 'pending' ? 'bg-amber-100 text-amber-800' :
                             'bg-rose-100 text-rose-800'
                           }`}>

--- a/frontend/src/pages/signals.tsx
+++ b/frontend/src/pages/signals.tsx
@@ -202,7 +202,7 @@ const SignalsPage: React.FC = () => {
         case 'pending':
           return <Clock className="h-5 w-5 text-yellow-600" />;
         default:
-          return <AlertCircle className="h-5 w-5 text-gray-600" />;
+          return null;
       }
     };
 
@@ -220,11 +220,9 @@ const SignalsPage: React.FC = () => {
         <td className="px-6 py-4 whitespace-nowrap">
           <div className="flex items-center">
             {getStatusIcon()}
-            {signal.status !== 'error' && (
-              <span className={`ml-2 px-3 py-1 rounded-full text-xs font-medium ${getStatusColor(signal.status)}`}>
-                {signal.status}
-              </span>
-            )}
+            <span className={`ml-2 px-3 py-1 rounded-full text-xs font-medium ${getStatusColor(signal.status)}`}>
+              {signal.status}
+            </span>
           </div>
         </td>
         <td className="px-6 py-4 whitespace-nowrap">
@@ -235,12 +233,12 @@ const SignalsPage: React.FC = () => {
         </td>
         <td className="px-6 py-4 whitespace-nowrap">
           <div className="flex items-center">
-            {signal.action === 'buy' ?
+            {signal.action.toLowerCase() === 'buy' ?
               <TrendingUp className="h-4 w-4 text-emerald-600 mr-2" /> :
               <TrendingDown className="h-4 w-4 text-red-600 mr-2" />
             }
             <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-              signal.action === 'buy' ? 'bg-emerald-100 text-emerald-800' : 'bg-red-100 text-red-800'
+              signal.action.toLowerCase() === 'buy' ? 'bg-emerald-100 text-emerald-800' : 'bg-red-100 text-red-800'
             }`}>
               {signal.action.toUpperCase()}
             </span>


### PR DESCRIPTION
## Summary
- remove warning icon in signal widgets
- color statuses (processed/error) and actions (buy/sell)

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9bce4c1a083319dc187f85a87494e