### PR TITLE
Add idempotency key field to Signal model

### DIFF
--- a/alembic/versions/5f00e55d2fc1_add_idempotency_key_to_signals.py
+++ b/alembic/versions/5f00e55d2fc1_add_idempotency_key_to_signals.py
@@ -1,0 +1,37 @@
+"""add idempotency_key to signals
+
+Revision ID: 5f00e55d2fc1
+Revises: a518a2a016b9
+Create Date: 2025-08-30 13:27:41.595299
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5f00e55d2fc1'
+down_revision: Union[str, Sequence[str], None] = 'a518a2a016b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "signals", sa.Column("idempotency_key", sa.String(length=32), nullable=True)
+    )
+    op.create_index(
+        op.f("ix_signals_idempotency_key"),
+        "signals",
+        ["idempotency_key"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_signals_idempotency_key"), table_name="signals")
+    op.drop_column("signals", "idempotency_key")

--- a/app/models/signal.py
+++ b/app/models/signal.py
@@ -25,6 +25,7 @@ class Signal(Base):
     reason = Column(String(50), nullable=True)  # fibonacci_entry, fibonacci_exit, trailing_stop
     confidence = Column(Integer, nullable=True)  # Score 0-100
     tv_timestamp = Column(String(50), nullable=True)  # Timestamp original de TradingView
+    idempotency_key = Column(String(32), nullable=True, unique=True, index=True)  # Para deduplicación
 
     # NUEVO: Relación con usuario
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)


### PR DESCRIPTION
## Summary
- add `idempotency_key` column to `Signal` model for deduplication
- create Alembic migration to add `idempotency_key` with unique index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2fc1d37b08331883e1ef159613de2