### PR TITLE
Add risk management API endpoints

### DIFF
--- a/app/api/v1/risk.py
+++ b/app/api/v1/risk.py
@@ -1,191 +1,158 @@
 from fastapi import APIRouter, Depends, HTTPException
-from alpaca.common.exceptions import APIError
 from sqlalchemy.orm import Session
+from typing import Dict, Any
 from app.database import get_db
 from app.models.user import User
 from app.core.auth import get_current_verified_user
-from app.services.risk_manager import risk_manager
-from app.services.position_manager import position_manager
-
-# Symbols that should be treated as cash equivalents
-STABLE_COINS = {"USD", "ZUSD", "USDC", "USDT"}
+from app.services.risk_service import RiskService
+from app.services import portfolio_service
+from pydantic import BaseModel
 
 router = APIRouter()
 
-@router.get("/risk/status")
-async def get_risk_status(current_user: User = Depends(get_current_verified_user)):
-    """Get current risk management status and allocation info"""
-    try:
-        from app.integrations import broker_client
-        account = broker_client.get_account()
-        buying_power = float(getattr(account, "buying_power", 0))
-        portfolio_value = float(getattr(account, "portfolio_value", 0))
+class RiskLimitUpdate(BaseModel):
+    max_daily_drawdown: float = None
+    max_weekly_drawdown: float = None
+    max_position_size: float = None
+    max_orders_per_hour: int = None
+    max_orders_per_day: int = None
+    max_open_positions: int = None
+    trading_start_time: str = None
+    trading_end_time: str = None
+    allow_extended_hours: bool = None
 
-        allocation_info = risk_manager.get_allocation_info(buying_power)
+@router.get("/risk/summary")
+async def get_risk_summary(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user)
+):
+    """Obtener resumen del estado actual de riesgo"""
+    active_portfolio = portfolio_service.get_active(db, current_user)
+    if not active_portfolio:
+        raise HTTPException(status_code=400, detail="No active portfolio found")
+    
+    risk_service = RiskService(db)
+    summary = risk_service.get_risk_summary(current_user.id, active_portfolio.id)
+    
+    return summary
 
-        # DEBUG INFO - Vamos a incluir información de debug en la respuesta
-        debug_info = {
-            "alpaca_raw_positions": [],
-            "processed_positions": [],
-            "broker_client_type": str(type(broker_client)),
-            "has_trading_client": hasattr(broker_client, '_trading') and broker_client._trading is not None
-        }
-
-        # Obtener posiciones directamente de Alpaca para debug
-        if hasattr(broker_client, '_trading') and broker_client._trading:
-            try:
-                raw_alpaca_positions = broker_client._trading.get_all_positions()
-                for p in raw_alpaca_positions:
-                    debug_info["alpaca_raw_positions"].append({
-                        "symbol": p.symbol,
-                        "qty": str(p.qty),
-                        "has_market_value": hasattr(p, 'market_value'),
-                        "market_value_raw": str(getattr(p, 'market_value', 'NOT_FOUND')),
-                        "has_unrealized_pl": hasattr(p, 'unrealized_pl'),
-                        "unrealized_pl_raw": str(getattr(p, 'unrealized_pl', 'NOT_FOUND')),
-                        "has_unrealized_intraday_pl": hasattr(p, 'unrealized_intraday_pl'),
-                        "unrealized_intraday_pl_raw": str(getattr(p, 'unrealized_intraday_pl', 'NOT_FOUND')),
-                        "has_unrealized_today_pl": hasattr(p, 'unrealized_today_pl'),
-                        "unrealized_today_pl_raw": str(getattr(p, 'unrealized_today_pl', 'NOT_FOUND')),
-                        "all_attributes": [attr for attr in dir(p) if not attr.startswith('_') and 'pl' in attr.lower()]
-                    })
-            except Exception as e:
-                debug_info["alpaca_error"] = str(e)
-
-        # Build detailed positions using the complete information of Alpaca
-        detailed_positions = position_manager.get_detailed_positions()
-        position_details = []
-
-        for pos in detailed_positions:
-            symbol = pos['symbol']
-
-            # DEBUG: Agregar info de esta posición procesada
-            debug_info["processed_positions"].append({
-                "symbol": symbol,
-                "original_pos_data": pos
-            })
-
-            # Para stable coins, usar valores directos
-            if symbol in STABLE_COINS:
-                market_value = pos['market_value']
-                unrealized_pl = 0.0  # Las stable coins no tienen PnL
-            else:
-                # Para activos normales, usar los valores de Alpaca directamente
-                market_value = pos['market_value']
-                unrealized_pl = pos['unrealized_pl']  # SOLO PnL TOTAL desde compra
-
-            position_details.append({
-                "symbol": symbol,
-                "quantity": pos['quantity'],
-                "market_value": market_value,
-                "unrealized_pl": unrealized_pl,  # PnL TOTAL
-                "unrealized_plpc": pos.get('unrealized_plpc', 0.0),
-                "cost_basis": pos.get('cost_basis', 0.0),
-                "avg_entry_price": pos.get('avg_entry_price', 0.0),
-                "current_price": pos.get('current_price', 0.0),
-                "percentage": (market_value / portfolio_value * 100) if portfolio_value > 0 else 0,
-            })
-
-        # Simulate next positions (mantener igual)
-        symbols_to_simulate = ["AAPL", "MSFT", "AMZN", "GOOG"]
-        next_positions_simulation = []
-        for symbol in symbols_to_simulate:
-            try:
-                quote = broker_client.get_latest_quote(symbol)
-                price = float(getattr(quote, "ask_price", getattr(quote, "ap", 100000)))
-                simulated_qty = risk_manager.calculate_optimal_position_size(
-                    price=price,
-                    buying_power=buying_power,
-                    symbol=symbol,
-                )
-                simulated_value = simulated_qty * price
-                minimum_qty = risk_manager.get_symbol_minimum(symbol)
-                next_positions_simulation.append({
-                    "symbol": symbol,
-                    "current_price": price,
-                    "would_buy_qty": simulated_qty,
-                    "would_invest_usd": simulated_value,
-                    "minimum_required": minimum_qty,
-                    "can_enter": simulated_qty >= minimum_qty,
-                    "percentage_of_portfolio": (simulated_value / buying_power * 100) if buying_power > 0 else 0,
-                })
-            except Exception as e:
-                continue
-
-        return {
-            "account_info": {
-                "buying_power": buying_power,
-                "portfolio_value": portfolio_value,
-                "cash_percentage": (buying_power / portfolio_value * 100) if portfolio_value > 0 else 100,
-                "total_unrealized_pl": sum(pos["unrealized_pl"] for pos in position_details),
-            },
-            "allocation_info": allocation_info,
-            "current_positions": position_details,
-            "risk_metrics": {
-                "position_count": len(position_details),
-                "capital_utilization": ((portfolio_value - buying_power) / portfolio_value * 100) if portfolio_value > 0 else 0,
-                "largest_position_pct": max([p["percentage"] for p in position_details], default=0),
-                "concentration_risk": "High" if any(p["percentage"] > 40 for p in position_details) else "Medium" if any(p["percentage"] > 25 for p in position_details) else "Low",
-            },
-            "next_positions_simulation": next_positions_simulation,
-            "debug_info": debug_info  # NUEVA SECCIÓN DE DEBUG
-        }
-    except APIError as e:
-        raise HTTPException(
-            status_code=e.status_code or 502,
-            detail=f"Alpaca API error: {getattr(e, 'message', str(e))}",
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-@router.get("/risk/allocation-chart")
-async def get_allocation_chart_data(current_user: User = Depends(get_current_verified_user)):
-    """Get data for allocation pie chart"""
-    try:
-        raw_positions = position_manager.get_current_positions()
-        from app.integrations import broker_client
-        account = broker_client.get_account()
-        buying_power = float(getattr(account, "buying_power", 0))
-
-        chart_data = []
-        for symbol, qty in raw_positions.items():
-            if float(qty) <= 0:
-                continue
-            price = 1.0 if symbol in STABLE_COINS else 0.0
-            if symbol not in STABLE_COINS:
-                try:
-                    quote = broker_client.get_latest_quote(symbol)
-                    price = float(getattr(quote, "ask_price", getattr(quote, "ap", 0)))
-                except Exception:
-                    price = 0.0
-            market_value = price * float(qty)
-            print(f"DBG Chart {symbol} qty={qty} price={price} value={market_value}")
-            if market_value > 0:
-                chart_data.append({
-                    "name": symbol,
-                    "value": market_value,
-                    "color": _get_symbol_color(symbol),
-                })
-        if buying_power > 0:
-            chart_data.append({
-                "name": "Available Cash",
-                "value": buying_power,
-                "color": "#10B981",
-            })
-        return {"chart_data": chart_data}
-    except APIError as e:
-        raise HTTPException(
-            status_code=e.status_code or 502,
-            detail=f"Alpaca API error: {getattr(e, 'message', str(e))}",
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-def _get_symbol_color(symbol: str) -> str:
-    colors = {
-        "AAPL": "#F59E0B",
-        "MSFT": "#6366F1",
-        "AMZN": "#8B5CF6",
-        "GOOG": "#10B981",
+@router.get("/risk/limits")
+async def get_risk_limits(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user)
+):
+    """Obtener límites de riesgo actuales"""
+    active_portfolio = portfolio_service.get_active(db, current_user)
+    if not active_portfolio:
+        raise HTTPException(status_code=400, detail="No active portfolio found")
+    
+    risk_service = RiskService(db)
+    risk_limits = risk_service.get_or_create_risk_limits(current_user.id, active_portfolio.id)
+    
+    return {
+        "id": risk_limits.id,
+        "max_daily_drawdown": risk_limits.max_daily_drawdown,
+        "max_weekly_drawdown": risk_limits.max_weekly_drawdown,
+        "max_account_drawdown": risk_limits.max_account_drawdown,
+        "max_position_size": risk_limits.max_position_size,
+        "max_symbol_exposure": risk_limits.max_symbol_exposure,
+        "max_sector_exposure": risk_limits.max_sector_exposure,
+        "max_total_exposure": risk_limits.max_total_exposure,
+        "max_orders_per_hour": risk_limits.max_orders_per_hour,
+        "max_orders_per_day": risk_limits.max_orders_per_day,
+        "max_open_positions": risk_limits.max_open_positions,
+        "trading_start_time": risk_limits.trading_start_time,
+        "trading_end_time": risk_limits.trading_end_time,
+        "allow_extended_hours": risk_limits.allow_extended_hours,
+        "min_price": risk_limits.min_price,
+        "max_price": risk_limits.max_price,
+        "min_volume": risk_limits.min_volume,
+        "max_spread_percent": risk_limits.max_spread_percent,
+        "block_earnings_days": risk_limits.block_earnings_days,
+        "block_fomc_days": risk_limits.block_fomc_days,
+        "created_at": risk_limits.created_at,
+        "updated_at": risk_limits.updated_at
     }
-    return colors.get(symbol, "#6B7280")
+
+@router.put("/risk/limits")
+async def update_risk_limits(
+    updates: RiskLimitUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user)
+):
+    """Actualizar límites de riesgo"""
+    active_portfolio = portfolio_service.get_active(db, current_user)
+    if not active_portfolio:
+        raise HTTPException(status_code=400, detail="No active portfolio found")
+    
+    # Filtrar solo campos no None
+    update_data = {k: v for k, v in updates.dict().items() if v is not None}
+    
+    if not update_data:
+        raise HTTPException(status_code=400, detail="No valid updates provided")
+    
+    risk_service = RiskService(db)
+    updated_limits = risk_service.update_risk_limits(
+        current_user.id, 
+        active_portfolio.id, 
+        update_data
+    )
+    
+    return {
+        "message": "Risk limits updated successfully",
+        "updated_fields": list(update_data.keys()),
+        "limits": {
+            "max_daily_drawdown": updated_limits.max_daily_drawdown,
+            "max_orders_per_hour": updated_limits.max_orders_per_hour,
+            "max_orders_per_day": updated_limits.max_orders_per_day,
+            "max_open_positions": updated_limits.max_open_positions,
+        }
+    }
+
+@router.post("/risk/test-signal")
+async def test_signal_risk(
+    signal_data: Dict[str, Any],
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user)
+):
+    """Probar si una señal pasaría el risk management sin ejecutarla"""
+    from app.core.types import NormalizedSignal, SignalAction
+    from app.risk.manager import RiskManager
+    from datetime import datetime
+    
+    active_portfolio = portfolio_service.get_active(db, current_user)
+    if not active_portfolio:
+        raise HTTPException(status_code=400, detail="No active portfolio found")
+    
+    try:
+        # Crear señal de prueba
+        test_signal = NormalizedSignal(
+            symbol=signal_data.get("symbol", "AAPL"),
+            action=SignalAction(signal_data.get("action", "buy")),
+            strategy_id=signal_data.get("strategy_id", "test_strategy"),
+            quantity=signal_data.get("quantity", 10),
+            confidence=signal_data.get("confidence", 75),
+            reason=signal_data.get("reason", "test"),
+            source="test",
+            raw_payload=signal_data,
+            idempotency_key="test_" + str(datetime.now().timestamp()),
+            fired_at=datetime.now()
+        )
+        
+        # Evaluar con risk manager
+        risk_manager = RiskManager(db)
+        result = risk_manager.evaluate_signal(test_signal, current_user, active_portfolio)
+        
+        return {
+            "test_signal": {
+                "symbol": test_signal.symbol,
+                "action": test_signal.action,
+                "strategy_id": test_signal.strategy_id,
+                "quantity": test_signal.quantity
+            },
+            "risk_evaluation": result,
+            "note": "This was a test - no actual signal was saved or executed"
+        }
+        
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Test failed: {str(e)}")


### PR DESCRIPTION
## Summary
- Replace risk API module with endpoints for risk summary, limits retrieval and update, and test-signal evaluation

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'app.models.trade')*

------
https://chatgpt.com/codex/tasks/task_e_68b314300a388331b67d92b1b29ab57f