### PR TITLE
Fix incorrect SQLAlchemy DECIMAL import for Order model

### DIFF
--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,7 +1,16 @@
 # backend/app/models/order.py
 
-from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, Text, ForeignKey
-from sqlalchemy.dialects.postgresql import DECIMAL
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Float,
+    DateTime,
+    Boolean,
+    Text,
+    ForeignKey,
+    DECIMAL,
+)
 from sqlalchemy.orm import relationship
 from app.database import Base
 from app.core.types import OrderStatus, OrderType


### PR DESCRIPTION
## Summary
- fix order model to import DECIMAL from SQLAlchemy core instead of PostgreSQL dialect

## Testing
- `alembic revision --autogenerate -m "Add orders table"` *(fails: connection to server at "localhost" (::1), port 5432 failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.models.trade')*

------
https://chatgpt.com/codex/tasks/task_e_68b33070adf083319d9535e4895a0cca