### PR TITLE
Add automatic order processing scheduler and background tasks

### DIFF
--- a/app/execution/__init__.py
+++ b/app/execution/__init__.py
@@ -1,5 +1,15 @@
 from .order_manager import OrderManager
 from .broker_executor import BrokerExecutor
 from .order_processor import OrderProcessor
+from .scheduler import ExecutionScheduler, execution_scheduler
+from .background_tasks import BackgroundTaskManager, background_task_manager
 
-__all__ = ["OrderManager", "BrokerExecutor", "OrderProcessor"]
+__all__ = [
+    "OrderManager",
+    "BrokerExecutor",
+    "OrderProcessor",
+    "ExecutionScheduler",
+    "execution_scheduler",
+    "BackgroundTaskManager",
+    "background_task_manager",
+]

--- a/app/execution/background_tasks.py
+++ b/app/execution/background_tasks.py
@@ -1,0 +1,86 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from app.execution.scheduler import execution_scheduler
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundTaskManager:
+    """Manager para tareas en background del execution engine"""
+
+    def __init__(self):
+        self.tasks = []
+        self.is_running = False
+
+    async def start_all_tasks(self):
+        """Iniciar todas las tareas en background"""
+        if self.is_running:
+            logger.warning("Background tasks already running")
+            return
+
+        self.is_running = True
+        logger.info("Starting execution background tasks...")
+
+        try:
+            # Crear task para el scheduler
+            scheduler_task = asyncio.create_task(
+                execution_scheduler.start(),
+                name="execution_scheduler",
+            )
+            self.tasks.append(scheduler_task)
+
+            # Esperar a que todas las tareas terminen
+            await asyncio.gather(*self.tasks, return_exceptions=True)
+
+        except Exception as e:  # pragma: no cover - safeguard
+            logger.error(f"Error in background tasks: {e}")
+            await self.stop_all_tasks()
+
+    async def stop_all_tasks(self):
+        """Detener todas las tareas en background"""
+        if not self.is_running:
+            return
+
+        logger.info("Stopping execution background tasks...")
+        self.is_running = False
+
+        # Detener scheduler
+        execution_scheduler.stop()
+
+        # Cancelar todas las tareas
+        for task in self.tasks:
+            if not task.done():
+                task.cancel()
+
+        # Esperar a que se cancelen
+        if self.tasks:
+            await asyncio.gather(*self.tasks, return_exceptions=True)
+
+        self.tasks.clear()
+        logger.info("All execution background tasks stopped")
+
+
+# Instancia global del manager
+background_task_manager = BackgroundTaskManager()
+
+
+@asynccontextmanager
+async def execution_lifespan(app):
+    """Context manager para manejar el lifecycle de las tareas en background"""
+    # Startup
+    logger.info("Starting execution engine background tasks...")
+    task = asyncio.create_task(background_task_manager.start_all_tasks())
+
+    yield
+
+    # Shutdown
+    logger.info("Shutting down execution engine background tasks...")
+    await background_task_manager.stop_all_tasks()
+
+    if not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:  # pragma: no cover - silence cancellation
+            pass

--- a/app/execution/scheduler.py
+++ b/app/execution/scheduler.py
@@ -1,0 +1,183 @@
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Dict, Any
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.execution.order_processor import OrderProcessor
+from app.models.order import Order
+from app.core.types import OrderStatus
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutionScheduler:
+    """Scheduler para procesar órdenes automáticamente"""
+
+    def __init__(self):
+        self.is_running = False
+        self.process_interval = 30  # Segundos entre procesamiento
+        self.fill_update_interval = 60  # Segundos entre actualización de fills
+        self.last_process_time = None
+        self.last_fill_update_time = None
+
+    async def start(self):
+        """Iniciar el scheduler"""
+        if self.is_running:
+            logger.warning("Scheduler already running")
+            return
+
+        self.is_running = True
+        logger.info("Starting execution scheduler...")
+
+        # Iniciar tareas en paralelo
+        await asyncio.gather(
+            self._order_processing_loop(),
+            self._fill_update_loop(),
+            self._cleanup_loop(),
+        )
+
+    def stop(self):
+        """Detener el scheduler"""
+        self.is_running = False
+        logger.info("Execution scheduler stopped")
+
+    async def _order_processing_loop(self):
+        """Loop principal de procesamiento de órdenes"""
+        while self.is_running:
+            try:
+                db: Session = next(get_db())
+                processor = OrderProcessor(db)
+
+                # Contar órdenes pendientes antes de procesar
+                pending_count = (
+                    db.query(Order).filter(Order.status == OrderStatus.NEW).count()
+                )
+
+                if pending_count > 0:
+                    logger.info(f"Processing {pending_count} pending orders...")
+
+                    result = processor.process_pending_orders()
+                    self.last_process_time = datetime.utcnow()
+
+                    if result["successful"] > 0 or result["failed"] > 0:
+                        logger.info(
+                            "Order processing completed: %s successful, %s failed, %s retries",
+                            result["successful"],
+                            result["failed"],
+                            result["retries_scheduled"],
+                        )
+                else:
+                    # Solo log detallado cada 5 minutos cuando no hay órdenes
+                    if not hasattr(self, "_last_no_orders_log") or (
+                        datetime.utcnow() - self._last_no_orders_log
+                        > timedelta(minutes=5)
+                    ):
+                        logger.debug("No pending orders to process")
+                        self._last_no_orders_log = datetime.utcnow()
+
+                db.close()
+
+            except Exception as e:  # pragma: no cover - just in case
+                logger.error(f"Error in order processing loop: {e}")
+                if "db" in locals():
+                    db.close()
+
+            # Esperar antes del siguiente ciclo
+            await asyncio.sleep(self.process_interval)
+
+    async def _fill_update_loop(self):
+        """Loop para actualizar fills de órdenes activas"""
+        while self.is_running:
+            try:
+                db: Session = next(get_db())
+                processor = OrderProcessor(db)
+
+                # Actualizar fills de órdenes activas
+                result = processor.update_order_fills()
+                self.last_fill_update_time = datetime.utcnow()
+
+                if result["updated"] > 0:
+                    logger.info(
+                        "Fill update completed: %s checked, %s updated, %s filled",
+                        result["checked"],
+                        result["updated"],
+                        result["filled"],
+                    )
+
+                db.close()
+
+            except Exception as e:  # pragma: no cover - just in case
+                logger.error(f"Error in fill update loop: {e}")
+                if "db" in locals():
+                    db.close()
+
+            # Esperar antes del siguiente ciclo (menos frecuente)
+            await asyncio.sleep(self.fill_update_interval)
+
+    async def _cleanup_loop(self):
+        """Loop para tareas de limpieza periódicas"""
+        while self.is_running:
+            try:
+                db: Session = next(get_db())
+
+                # Limpiar órdenes con errores muy antiguas (opcional)
+                cutoff_date = datetime.utcnow() - timedelta(days=30)
+                old_error_orders = (
+                    db.query(Order)
+                    .filter(
+                        Order.status == OrderStatus.ERROR,
+                        Order.created_at < cutoff_date,
+                    )
+                    .count()
+                )
+
+                if old_error_orders > 0:
+                    logger.info(
+                        "Found %s old error orders (cleanup could be implemented)",
+                        old_error_orders,
+                    )
+
+                # Estadísticas periódicas (cada 30 minutos)
+                processor = OrderProcessor(db)
+                stats = processor.get_order_statistics()
+
+                logger.info("Execution stats: %s", stats["status_breakdown"])
+
+                db.close()
+
+            except Exception as e:  # pragma: no cover - just in case
+                logger.error(f"Error in cleanup loop: {e}")
+                if "db" in locals():
+                    db.close()
+
+            # Cleanup cada 30 minutos
+            await asyncio.sleep(30 * 60)
+
+    def get_status(self) -> Dict[str, Any]:
+        """Obtener estado del scheduler"""
+        return {
+            "is_running": self.is_running,
+            "process_interval": self.process_interval,
+            "fill_update_interval": self.fill_update_interval,
+            "last_process_time": self.last_process_time.isoformat()
+            if self.last_process_time
+            else None,
+            "last_fill_update_time": self.last_fill_update_time.isoformat()
+            if self.last_fill_update_time
+            else None,
+        }
+
+
+# Instancia global del scheduler
+execution_scheduler = ExecutionScheduler()
+
+
+async def start_execution_scheduler():
+    """Función para iniciar el scheduler desde FastAPI"""
+    await execution_scheduler.start()
+
+
+def stop_execution_scheduler():
+    """Función para detener el scheduler"""
+    execution_scheduler.stop()

--- a/app/main.py
+++ b/app/main.py
@@ -10,10 +10,12 @@ from app.api.v1 import auth, trades, strategies, portfolio, risk, execution
 from app.database import SessionLocal
 from app.services import portfolio_service
 from app.integrations import refresh_broker_client
+from app.execution.background_tasks import execution_lifespan
 
 app = FastAPI(
     title=settings.app_name,
-    debug=settings.debug
+    debug=settings.debug,
+    lifespan=execution_lifespan,
 )
 
 # CORS para el frontend React


### PR DESCRIPTION
## Summary
- add ExecutionScheduler for periodic order processing, fill updates, and cleanup
- manage scheduler through BackgroundTaskManager with FastAPI lifespan integration
- expose execution background utilities via package exports and wire into app startup

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.models.trade')*

------
https://chatgpt.com/codex/tasks/task_e_68b3634383f08331b4fa7925055745c7