### PR TITLE
Use timedelta for risk manager hourly queries

### DIFF
--- a/app/risk/manager.py
+++ b/app/risk/manager.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any, Optional, Tuple
 from sqlalchemy.orm import Session
 from sqlalchemy import func, and_
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from app.core.types import NormalizedSignal, OrderIntent
 from app.models.risk_limit import RiskLimit
 from app.models.trades import Trade
@@ -135,7 +135,7 @@ class RiskManager:
         now = now_eastern()
         
         # Contar órdenes en la última hora
-        one_hour_ago = now.replace(minute=now.minute-60) if now.minute >= 60 else now.replace(hour=now.hour-1)
+        one_hour_ago = now - timedelta(hours=1)
         orders_last_hour = self.db.query(Signal).filter(
             and_(
                 Signal.user_id == user_id,


### PR DESCRIPTION
## Summary
- use `now - timedelta(hours=1)` when computing `one_hour_ago` in risk manager
- import `timedelta` from `datetime`

## Testing
- `python - <<'PY'
from sqlalchemy import create_engine, and_
from sqlalchemy.orm import sessionmaker
from app.database import Base
from app.models import User, Portfolio, Signal
from app.utils.time import now_eastern
from datetime import timedelta

engine = create_engine('sqlite:///:memory:')
SessionLocal = sessionmaker(bind=engine)
Base.metadata.create_all(engine)

session = SessionLocal()
user = User(email='b@b.com', username='user2', password_hash='hash')
session.add(user)
session.commit()
portfolio = Portfolio(name='p2', api_key_encrypted='key', secret_key_encrypted='secret', base_url='http://', user_id=user.id)
session.add(portfolio)
session.commit()
now = now_eastern()
session.add_all([
    Signal(user_id=user.id, portfolio_id=portfolio.id, timestamp=now - timedelta(minutes=30), status='executed', strategy_id='s1', symbol='MSFT', action='buy', quantity=1, price=1),
    Signal(user_id=user.id, portfolio_id=portfolio.id, timestamp=now - timedelta(hours=2), status='executed', strategy_id='s1', symbol='MSFT', action='buy', quantity=1, price=1)
])
session.commit()
one_hour_ago = now - timedelta(hours=1)
count = session.query(Signal).filter(and_(Signal.user_id==user.id, Signal.portfolio_id==portfolio.id, Signal.timestamp>=one_hour_ago, Signal.status.in_(['executed','processing']))).count()
print('orders_last_hour', count)
PY`
- `pytest` (fails: ModuleNotFoundError: No module named 'app.models.trade')

------
https://chatgpt.com/codex/tasks/task_e_68b37a93fb288331b27e899ac463ffe0