### PR TITLE
Implement symbol exposure limit check

### DIFF
--- a/tests/test_risk_manager_app.py
+++ b/tests/test_risk_manager_app.py
@@ -31,6 +31,25 @@ class DummyBroker:
         return SimpleNamespace(price=self.price)
 
 
+class DummyQuery:
+    def __init__(self, value):
+        self.value = value
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def scalar(self):
+        return self.value
+
+
+class DummyDB:
+    def __init__(self, value):
+        self.value = value
+
+    def query(self, *args, **kwargs):
+        return DummyQuery(self.value)
+
+
 def test_quantity_exceeds_limit(monkeypatch):
     rm = RiskManager(db_session=None)
     monkeypatch.setattr(manager_module, "broker_client", DummyBroker(price=100.0))
@@ -47,4 +66,23 @@ def test_quantity_within_limit(monkeypatch):
     risk_limits = SimpleNamespace(max_position_size=0.05)
     qty = rm._calculate_position_size(signal, 1, 1, risk_limits)
     assert qty == 4
+
+
+def test_symbol_exposure_exceeds_limit(monkeypatch):
+    db = DummyDB(15)  # 15 shares open
+    rm = RiskManager(db_session=db)
+    monkeypatch.setattr(manager_module, "broker_client", DummyBroker(price=100.0))
+    risk_limits = SimpleNamespace(max_symbol_exposure=0.10)
+    result = rm._check_symbol_exposure("AAPL", 1, 1, risk_limits)
+    assert not result["approved"]
+    assert "Symbol exposure limit exceeded" in result["reason"]
+
+
+def test_symbol_exposure_within_limit(monkeypatch):
+    db = DummyDB(5)  # 5 shares open
+    rm = RiskManager(db_session=db)
+    monkeypatch.setattr(manager_module, "broker_client", DummyBroker(price=100.0))
+    risk_limits = SimpleNamespace(max_symbol_exposure=0.10)
+    result = rm._check_symbol_exposure("AAPL", 1, 1, risk_limits)
+    assert result["approved"]
 


### PR DESCRIPTION
## Summary
- compute open position USD value using market price
- reject signals when symbol exposure exceeds configured percentage of capital
- add tests covering symbol exposure checks

## Testing
- `pytest` *(fails: tests/test_risk_route.py, tests/test_websocket.py during collection)*
- `pytest tests/test_risk_manager_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b37d4636c88331b9224a3c5d7d7f51