### PR TITLE
feat: compute position size using market price

### DIFF
--- a/app/services/risk_service.py
+++ b/app/services/risk_service.py
@@ -4,7 +4,7 @@ from sqlalchemy import func, and_
 from app.models.risk_limit import RiskLimit
 from app.models.user import User
 from app.models.portfolio import Portfolio
-from app.models.trade import Trade
+from app.models.trades import Trade
 from app.models.signal import Signal
 from datetime import datetime
 from app.utils.time import now_eastern

--- a/tests/test_order_manager_position_size.py
+++ b/tests/test_order_manager_position_size.py
@@ -1,0 +1,46 @@
+import types
+import pytest
+
+from app.execution import order_manager
+from app.models.signal import Signal
+
+
+def test_calculate_position_size_fractionable(monkeypatch):
+    class DummyOE:
+        def __init__(self):
+            self.broker = types.SimpleNamespace(is_asset_fractionable=lambda s: True)
+        def map_symbol(self, symbol):
+            return symbol
+        def _get_market_price(self, symbol):
+            return 50
+        def is_crypto(self, symbol):
+            return False
+    monkeypatch.setattr(order_manager, "OrderExecutor", DummyOE)
+    om = order_manager.OrderManager(db=None)
+    signal = Signal(symbol="AAPL", action="buy", strategy_id="s")
+    qty = om.calculate_position_size(signal, available_capital=1000, max_position_pct=0.1)
+    assert qty == 2.0
+
+
+def test_calculate_position_size_non_fractionable_insufficient_capital(monkeypatch):
+    class DummyOE:
+        def __init__(self):
+            self.broker = types.SimpleNamespace(is_asset_fractionable=lambda s: False)
+        def map_symbol(self, symbol):
+            return symbol
+        def _get_market_price(self, symbol):
+            return 100
+        def is_crypto(self, symbol):
+            return False
+    monkeypatch.setattr(order_manager, "OrderExecutor", DummyOE)
+    om = order_manager.OrderManager(db=None)
+    signal = Signal(symbol="AAPL", action="buy", strategy_id="s")
+    with pytest.raises(ValueError):
+        om.calculate_position_size(signal, available_capital=50, max_position_pct=0.1)
+
+
+def test_calculate_position_size_uses_signal_quantity():
+    om = order_manager.OrderManager(db=None)
+    signal = Signal(symbol="AAPL", action="buy", strategy_id="s", quantity=5)
+    qty = om.calculate_position_size(signal, available_capital=1000, max_position_pct=0.1)
+    assert qty == 5.0


### PR DESCRIPTION
## Summary
- compute position size using market price and capital constraints
- expose risk status endpoint and fix risk service import
- add tests for order manager position sizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3879ee9048331b4f29e321eb60350