### PR TITLE
Use buying power for fund checks and add margin account tests

### DIFF
--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -213,8 +213,8 @@ class OrderExecutor:
             raise ValueError(f"Maximum positions limit reached ({limit})")
 
         account = self.broker.get_account()
-        available_cash = float(account.cash)
-        print(f"💵 Available cash: ${available_cash:,.2f}")
+        buying_power = float(account.buying_power)
+        print(f"💵 Available buying power: ${buying_power:,.2f}")
 
         is_fractionable = self.broker.is_asset_fractionable(correct_symbol)
         print(f"🔍 Asset {correct_symbol} is fractionable: {is_fractionable}")
@@ -243,8 +243,10 @@ class OrderExecutor:
         print(f"   - Estimated cost: ${estimated_cost:,.2f}")
         print(f"   - Is fractionable: {is_fractionable}")
 
-        if estimated_cost > available_cash:
-            raise ValueError(f"Insufficient cash. Need: ${estimated_cost:.2f}, Available: ${available_cash:.2f}")
+        if estimated_cost > buying_power:
+            raise ValueError(
+                f"Insufficient buying power. Need: ${estimated_cost:.2f}, Available: ${buying_power:.2f}"
+            )
 
         print("📤 Submitting order to broker...")
         if self.is_crypto(signal.symbol):

--- a/app/services/position_manager.py
+++ b/app/services/position_manager.py
@@ -101,9 +101,9 @@ class PositionManager:
         if current_qty == 0 and current_positions >= limit:
             raise ValueError(f"Maximum positions limit reached ({limit}). Current: {current_positions}")
 
-        # 2. Verificar efectivo disponible
+        # 2. Verificar poder de compra disponible
         account = self.broker.get_account()
-        available_cash = float(account.cash)
+        buying_power = float(account.buying_power)
 
         # Estimar costo de la orden (precio aproximado)
         try:
@@ -120,13 +120,15 @@ class PositionManager:
 
             estimated_cost = price * calculated_quantity
 
-            if estimated_cost > available_cash:
-                raise ValueError(f"Insufficient cash. Need: ${estimated_cost:.2f}, Available: ${available_cash:.2f}")
+            if estimated_cost > buying_power:
+                raise ValueError(
+                    f"Insufficient buying power. Need: ${estimated_cost:.2f}, Available: ${buying_power:.2f}"
+                )
 
         except Exception as e:
             if isinstance(e, ValueError):
                 raise
-            logger.warning(f"Could not validate cash for {signal.symbol}: {e}")
+            logger.warning(f"Could not validate buying power for {signal.symbol}: {e}")
 
         return True
 

--- a/tests/test_position_limit.py
+++ b/tests/test_position_limit.py
@@ -18,7 +18,7 @@ class DummyPM:
 
 class DummyBroker:
     def get_account(self):
-        return types.SimpleNamespace(cash="1000")
+        return types.SimpleNamespace(buying_power="1000")
 
 
 def test_order_blocked_when_limit_exceeded(monkeypatch):

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -5,7 +5,7 @@ from app.services.position_manager import PositionManager
 from app.models.signal import Signal
 
 
-def test_validate_buy_signal_insufficient_cash(monkeypatch):
+def test_validate_buy_signal_insufficient_buying_power(monkeypatch):
     pm = PositionManager()
 
     class DummyBroker:
@@ -16,7 +16,7 @@ def test_validate_buy_signal_insufficient_cash(monkeypatch):
             return None
 
         def get_account(self):
-            return SimpleNamespace(cash=50)
+            return SimpleNamespace(buying_power=50)
 
         def get_latest_quote(self, symbol):
             return SimpleNamespace(ask_price=20)
@@ -34,4 +34,34 @@ def test_validate_buy_signal_insufficient_cash(monkeypatch):
 
     with pytest.raises(ValueError):
         pm.validate_buy_signal(signal, calculated_quantity=3)
+
+
+def test_validate_buy_signal_margin_account(monkeypatch):
+    pm = PositionManager()
+
+    class DummyBroker:
+        def get_positions(self):
+            return []
+
+        def get_position(self, symbol):
+            return None
+
+        def get_account(self):
+            return SimpleNamespace(cash=0, buying_power=1000)
+
+        def get_latest_quote(self, symbol):
+            return SimpleNamespace(ask_price=20)
+
+        def get_latest_crypto_quote(self, symbol):
+            return SimpleNamespace(ask_price=20)
+
+        def get_latest_trade(self, symbol):
+            return SimpleNamespace(price=15)
+
+    dummy = DummyBroker()
+    monkeypatch.setattr(PositionManager, "broker", property(lambda self: dummy))
+
+    signal = Signal(symbol="AAPL", action="buy", strategy_id="s")
+
+    assert pm.validate_buy_signal(signal, calculated_quantity=3)
 


### PR DESCRIPTION
## Summary
- Use account buying power instead of cash when validating buy orders
- Update validation and error messaging to reflect buying power
- Add tests for margin accounts and adjust existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b397eb3fb88331946f5368f1757255