### PR TITLE
feat(alpaca): verify crypto symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Create a portfolio using your Alpaca API credentials. The libraries
 `alpaca-trade-api` and `alpaca-py` are required and are included in
 `requirements.txt` and `app/requirements.txt`.
 
+## Alpaca Integration
+
+When credentials are configured, the Alpaca client verifies whether a symbol
+is a crypto asset by querying the Alpaca asset endpoint. Without credentials,
+the client falls back to a simple heuristic that looks for a slash or common
+stablecoin suffixes (``USD``, ``USDT``, ``USDC``).
+
 Each user has a **position_limit** value determining how many open positions they
 may hold at once. The default limit is 7 and can be modified from the profile
 page or via the API.

--- a/tests/test_alpaca_client.py
+++ b/tests/test_alpaca_client.py
@@ -71,3 +71,22 @@ def test_check_crypto_status_handles_exception(monkeypatch):
     monkeypatch.setattr(client, "_trading", DummyTrading())
     assert client.check_crypto_status() is False
 
+
+def test_is_crypto_symbol_uses_api(monkeypatch):
+    client = AlpacaClient()
+
+    class DummyTrading:
+        def get_asset(self, symbol):
+            assert symbol == "BTCUSD"
+            return type("A", (), {"asset_class": "crypto"})()
+
+    monkeypatch.setattr(client, "_trading", DummyTrading())
+    assert client.is_crypto_symbol("BTCUSD") is True
+
+
+def test_is_crypto_symbol_fallback():
+    client = AlpacaClient()
+    client._trading = None
+    assert client.is_crypto_symbol("BTC/USD") is True
+    assert client.is_crypto_symbol("AAPL") is False
+


### PR DESCRIPTION
## Summary
- verify crypto symbols by checking Alpaca asset class when credentials exist
- document crypto symbol detection in the Alpaca integration
- test crypto symbol detection logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b398b6a918833195835f3b174720da