### PR TITLE
feat: centralize symbol mappings in database

### DIFF
--- a/alembic/versions/5ef44a2c3a3e_add_symbol_mapping_table.py
+++ b/alembic/versions/5ef44a2c3a3e_add_symbol_mapping_table.py
@@ -1,0 +1,32 @@
+"""add symbol mapping table
+
+Revision ID: 5ef44a2c3a3e
+Revises: 8db7b36ec533
+Create Date: 2025-08-31 00:45:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '5ef44a2c3a3e'
+down_revision: Union[str, Sequence[str], None] = '8db7b36ec533'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'symbol_mappings',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('raw_symbol', sa.String(length=50), nullable=False, unique=True),
+        sa.Column('broker_symbol', sa.String(length=50), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('symbol_mappings')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.trades import Trade
 from app.models.portfolio import Portfolio
 from app.models.risk_limit import RiskLimit
 from .order import Order
+from .symbol_mapping import SymbolMapping
 
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "Portfolio",
     "RiskLimit",
     "Order",
+    "SymbolMapping",
 ]

--- a/app/models/symbol_mapping.py
+++ b/app/models/symbol_mapping.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String
+from app.database import Base
+
+
+class SymbolMapping(Base):
+    """Represents mapping from external symbols to broker symbols."""
+
+    __tablename__ = "symbol_mappings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    raw_symbol = Column(String(50), unique=True, nullable=False, index=True)
+    broker_symbol = Column(String(50), nullable=False)

--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 from alpaca.common.exceptions import APIError
 from sqlalchemy.exc import SQLAlchemyError
+from app.services.symbol_mapper import get_mapped_symbol
 
 logger = logging.getLogger(__name__)
 
@@ -29,14 +30,8 @@ class OrderExecutor:
         return '/' in symbol or symbol.endswith('USD')
 
     def map_symbol(self, symbol: str) -> str:
-        """Convert TradingView symbols to Kraken format."""
-        symbol_map = {
-            'BTCUSD': 'BTC/USD',
-            'ETHUSD': 'ETH/USD',
-            'SOLUSD': 'SOL/USD',
-            'BCHUSD': 'BCH/USD',
-        }
-        mapped = symbol_map.get(symbol, symbol)
+        """Convert external symbols to broker format using DB mapping."""
+        mapped = get_mapped_symbol(symbol)
         print(f"🔄 Symbol mapping: {symbol} -> {mapped}")
         return mapped
 

--- a/app/services/symbol_mapper.py
+++ b/app/services/symbol_mapper.py
@@ -1,0 +1,57 @@
+"""Utilities for symbol mapping stored in the database."""
+from typing import Optional
+from sqlalchemy.orm import Session
+from app.database import SessionLocal
+from app.models.symbol_mapping import SymbolMapping
+
+
+def get_mapped_symbol(symbol: str, db: Optional[Session] = None) -> str:
+    """Return mapped broker symbol for given raw symbol.
+
+    If no mapping is found or database is unavailable, returns the original
+    symbol.
+    """
+    close_db = False
+    if db is None:
+        db = SessionLocal()
+        close_db = True
+    try:
+        mapping = (
+            db.query(SymbolMapping)
+            .filter(SymbolMapping.raw_symbol == symbol)
+            .first()
+        )
+        return mapping.broker_symbol if mapping else symbol
+    except Exception:
+        # If anything goes wrong (e.g., DB not available), fall back
+        return symbol
+    finally:
+        if close_db:
+            db.close()
+
+
+def upsert_symbol_mapping(
+    raw_symbol: str, broker_symbol: str, db: Optional[Session] = None
+) -> None:
+    """Create or update a symbol mapping entry."""
+    close_db = False
+    if db is None:
+        db = SessionLocal()
+        close_db = True
+    try:
+        mapping = (
+            db.query(SymbolMapping)
+            .filter(SymbolMapping.raw_symbol == raw_symbol)
+            .first()
+        )
+        if mapping:
+            mapping.broker_symbol = broker_symbol
+        else:
+            mapping = SymbolMapping(
+                raw_symbol=raw_symbol, broker_symbol=broker_symbol
+            )
+            db.add(mapping)
+        db.commit()
+    finally:
+        if close_db:
+            db.close()

--- a/app/services/trade_service.py
+++ b/app/services/trade_service.py
@@ -2,16 +2,10 @@ from datetime import datetime
 import statistics
 from sqlalchemy.orm import Session
 from app.models.trades import Trade
-
+from app.services.symbol_mapper import get_mapped_symbol
 
 
 class TradeService:
-    SYMBOL_MAP = {
-        'BTCUSD': 'BTC/USD',
-        'ETHUSD': 'ETH/USD',
-        'SOLUSD': 'SOL/USD',
-        'BCHUSD': 'BCH/USD',
-    }
 
     def __init__(self, db: Session):
         self.db = db
@@ -19,7 +13,7 @@ class TradeService:
         self.broker = broker_client
 
     def _map_symbol(self, symbol: str) -> str:
-        return self.SYMBOL_MAP.get(symbol, symbol)
+        return get_mapped_symbol(symbol, self.db)
 
     def _get_current_price(self, symbol: str) -> float:
         try:

--- a/tests/test_symbol_mapping.py
+++ b/tests/test_symbol_mapping.py
@@ -1,11 +1,37 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base
 from app.services.trade_service import TradeService
 from app.services.order_executor import OrderExecutor
+from app.services import symbol_mapper
+from app.models.symbol_mapping import SymbolMapping
+
+
+# Set up in-memory database shared across sessions
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+SessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(engine)
+
+# Insert mapping using service function
+with SessionLocal() as db:
+    symbol_mapper.upsert_symbol_mapping("BCHUSD", "BCH/USD", db)
+
+# Patch symbol mapper's SessionLocal to use testing session
+symbol_mapper.SessionLocal = SessionLocal
 
 
 def test_bchusd_mapping():
     service = TradeService.__new__(TradeService)
-    assert service.SYMBOL_MAP.get('BCHUSD') == 'BCH/USD'
+    with SessionLocal() as db:
+        service.db = db
+        assert service._map_symbol("BCHUSD") == "BCH/USD"
 
     oe = OrderExecutor()
-    mapped = oe.map_symbol('BCHUSD')
-    assert mapped == 'BCH/USD'
+    mapped = oe.map_symbol("BCHUSD")
+    assert mapped == "BCH/USD"


### PR DESCRIPTION
## Summary
- add `symbol_mappings` table and service for runtime symbol lookups
- use centralized mapping in TradeService and OrderExecutor
- test symbol mapping via database to support runtime updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b39a9f8c7c8331bff071bbc109d3fb