### PR TITLE
Include shorts in position counting

### DIFF
--- a/app/services/position_manager.py
+++ b/app/services/position_manager.py
@@ -86,7 +86,7 @@ class PositionManager:
     def count_open_positions(self):
         """Contar posiciones abiertas"""
         positions = self.get_current_positions()
-        return len([qty for qty in positions.values() if qty > 0])
+        return len([qty for qty in positions.values() if abs(qty) > 0])
 
     def validate_buy_signal(self, signal: Signal, calculated_quantity, limit: int | None = None):
         """Validar señal de compra"""

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -65,3 +65,47 @@ def test_validate_buy_signal_margin_account(monkeypatch):
 
     assert pm.validate_buy_signal(signal, calculated_quantity=3)
 
+
+def test_count_open_positions_includes_negative(monkeypatch):
+    pm = PositionManager()
+    monkeypatch.setattr(
+        PositionManager,
+        "get_current_positions",
+        lambda self: {"AAPL": 1, "TSLA": -2, "MSFT": 0},
+    )
+    assert pm.count_open_positions() == 2
+
+
+def test_validate_buy_signal_limit_with_negative_positions(monkeypatch):
+    pm = PositionManager()
+    positions = {"AAPL": 1, "TSLA": -1}
+
+    monkeypatch.setattr(
+        PositionManager, "get_current_positions", lambda self: positions
+    )
+    monkeypatch.setattr(
+        PositionManager,
+        "get_position_quantity",
+        lambda self, symbol: positions.get(symbol, 0),
+    )
+
+    class DummyBroker:
+        def get_account(self):
+            return SimpleNamespace(buying_power=1000)
+
+        def get_latest_quote(self, symbol):
+            return SimpleNamespace(ask_price=10)
+
+        def get_latest_crypto_quote(self, symbol):
+            return SimpleNamespace(ask_price=10)
+
+        def get_latest_trade(self, symbol):
+            return SimpleNamespace(price=10)
+
+    dummy = DummyBroker()
+    monkeypatch.setattr(PositionManager, "broker", property(lambda self: dummy))
+
+    signal = Signal(symbol="MSFT", action="buy", strategy_id="s")
+    with pytest.raises(ValueError):
+        pm.validate_buy_signal(signal, calculated_quantity=1, limit=2)
+


### PR DESCRIPTION
## Summary
- Count open positions using absolute quantity to include shorts
- Cover negative positions in position manager validation tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b39d2ea06483318b6d018837d9e7eb