### PR TITLE
Add StrategyExitRules model and SQL migration

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.portfolio import Portfolio
 from app.models.risk_limit import RiskLimit
 from .order import Order
 from .symbol_mapping import SymbolMapping
+from .strategy_exit_rules import StrategyExitRules
 
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "RiskLimit",
     "Order",
     "SymbolMapping",
+    "StrategyExitRules",
 ]

--- a/app/models/strategy_exit_rules.py
+++ b/app/models/strategy_exit_rules.py
@@ -1,0 +1,44 @@
+from sqlalchemy import Column, String, Float, Boolean, DateTime, UniqueConstraint
+from sqlalchemy.ext.declarative import declarative_base
+from app.database import Base
+from app.utils.time import now_eastern
+from datetime import datetime
+
+
+class StrategyExitRules(Base):
+    __tablename__ = "strategy_exit_rules"
+
+    id = Column(String(50), primary_key=True, index=True)  # strategy_id
+    
+    # Porcentajes para Stop Loss y Take Profit
+    stop_loss_pct = Column(Float, nullable=False, default=0.02)  # 2%
+    take_profit_pct = Column(Float, nullable=False, default=0.04)  # 4%
+    
+    # Trailing Stop configuration
+    trailing_stop_pct = Column(Float, nullable=False, default=0.015)  # 1.5%
+    use_trailing = Column(Boolean, nullable=False, default=True)
+    
+    # Risk management
+    risk_reward_ratio = Column(Float, nullable=False, default=2.0)  # 1:2
+    
+    # Timestamps
+    created_at = Column(DateTime(timezone=True), default=now_eastern)
+    updated_at = Column(DateTime(timezone=True), default=now_eastern, onupdate=now_eastern)
+
+    def __repr__(self):
+        return f"<StrategyExitRules({self.id}: SL={self.stop_loss_pct*100}%, TP={self.take_profit_pct*100}%)>"
+
+    def calculate_exit_prices(self, entry_price: float, side: str = "buy") -> dict:
+        """Calcular precios de salida basados en precio de entrada"""
+        if side.lower() == "buy":
+            stop_loss_price = entry_price * (1 - self.stop_loss_pct)
+            take_profit_price = entry_price * (1 + self.take_profit_pct)
+        else:  # sell/short
+            stop_loss_price = entry_price * (1 + self.stop_loss_pct)
+            take_profit_price = entry_price * (1 - self.take_profit_pct)
+            
+        return {
+            "stop_loss_price": round(stop_loss_price, 2),
+            "take_profit_price": round(take_profit_price, 2),
+            "entry_price": entry_price
+        }

--- a/migrations/add_strategy_exit_rules.sql
+++ b/migrations/add_strategy_exit_rules.sql
@@ -1,0 +1,19 @@
+-- Crear tabla strategy_exit_rules
+CREATE TABLE strategy_exit_rules (
+    id VARCHAR(50) PRIMARY KEY,
+    stop_loss_pct FLOAT NOT NULL DEFAULT 0.02,
+    take_profit_pct FLOAT NOT NULL DEFAULT 0.04,
+    trailing_stop_pct FLOAT NOT NULL DEFAULT 0.015,
+    use_trailing BOOLEAN NOT NULL DEFAULT TRUE,
+    risk_reward_ratio FLOAT NOT NULL DEFAULT 2.0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Índices para performance
+CREATE INDEX idx_strategy_exit_rules_id ON strategy_exit_rules(id);
+
+-- Insertar reglas por defecto para estrategias existentes
+INSERT INTO strategy_exit_rules (id) 
+SELECT DISTINCT strategy_id FROM signals 
+WHERE strategy_id NOT IN (SELECT id FROM strategy_exit_rules);


### PR DESCRIPTION
## Summary
- add `StrategyExitRules` SQLAlchemy model for strategy exit risk settings
- expose the new model in `app.models`
- add SQL migration for `strategy_exit_rules` table

## Testing
- `python - <<'PY'
from app.models.strategy_exit_rules import StrategyExitRules
ser = StrategyExitRules(stop_loss_pct=0.02, take_profit_pct=0.04, trailing_stop_pct=0.015, use_trailing=True, risk_reward_ratio=2.0)
print('Buy:', ser.calculate_exit_prices(100, 'buy'))
print('Sell:', ser.calculate_exit_prices(100, 'sell'))
PY`
- `pytest -q`
- `python - <<'PY'
from app.database import engine
from pathlib import Path
sql_path = Path('migrations/add_strategy_exit_rules.sql')
print('Running migration:', sql_path)
sql = sql_path.read_text()
try:
    with engine.begin() as conn:
        conn.exec_driver_sql(sql)
    print('Migration executed successfully.')
except Exception as e:
    print('Migration failed:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b3a4b3a66c8331b7641d0c4d5a9bb0