### PR TITLE
Add exit rules service with default rule management

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+from .exit_rules_service import ExitRulesService

--- a/app/services/exit_rules_service.py
+++ b/app/services/exit_rules_service.py
@@ -1,0 +1,95 @@
+from sqlalchemy.orm import Session
+from app.models.strategy_exit_rules import StrategyExitRules
+from typing import Optional, Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ExitRulesService:
+    def __init__(self, db: Session):
+        self.db = db
+    
+    def get_rules(self, strategy_id: str) -> StrategyExitRules:
+        """Obtener reglas de salida para una estrategia, crear defaults si no existen"""
+        rules = self.db.query(StrategyExitRules).filter(
+            StrategyExitRules.id == strategy_id
+        ).first()
+        
+        if not rules:
+            logger.info(f"Creating default exit rules for strategy: {strategy_id}")
+            rules = self.create_default_rules(strategy_id)
+            
+        return rules
+    
+    def create_default_rules(self, strategy_id: str) -> StrategyExitRules:
+        """Crear reglas por defecto para una estrategia"""
+        rules = StrategyExitRules(
+            id=strategy_id,
+            stop_loss_pct=0.02,      # 2%
+            take_profit_pct=0.04,    # 4% 
+            trailing_stop_pct=0.015, # 1.5%
+            use_trailing=True,
+            risk_reward_ratio=2.0
+        )
+        
+        self.db.add(rules)
+        self.db.commit()
+        self.db.refresh(rules)
+        
+        logger.info(f"Created default exit rules for {strategy_id}")
+        return rules
+    
+    def update_rules(self, strategy_id: str, **kwargs) -> StrategyExitRules:
+        """Actualizar reglas existentes"""
+        rules = self.get_rules(strategy_id)
+        
+        # Campos permitidos para actualización
+        allowed_fields = [
+            'stop_loss_pct', 'take_profit_pct', 'trailing_stop_pct',
+            'use_trailing', 'risk_reward_ratio'
+        ]
+        
+        for field, value in kwargs.items():
+            if field in allowed_fields and hasattr(rules, field):
+                setattr(rules, field, value)
+                logger.info(f"Updated {field} = {value} for strategy {strategy_id}")
+        
+        self.db.commit()
+        self.db.refresh(rules)
+        return rules
+    
+    def calculate_exit_prices(self, strategy_id: str, entry_price: float, side: str = "buy") -> Dict[str, Any]:
+        """Calcular precios de salida para una estrategia específica"""
+        rules = self.get_rules(strategy_id)
+        exit_prices = rules.calculate_exit_prices(entry_price, side)
+        
+        return {
+            **exit_prices,
+            "strategy_id": strategy_id,
+            "rules": {
+                "stop_loss_pct": rules.stop_loss_pct,
+                "take_profit_pct": rules.take_profit_pct,
+                "trailing_stop_pct": rules.trailing_stop_pct,
+                "use_trailing": rules.use_trailing,
+                "risk_reward_ratio": rules.risk_reward_ratio
+            }
+        }
+    
+    def get_all_rules(self) -> list[StrategyExitRules]:
+        """Obtener todas las reglas configuradas"""
+        return self.db.query(StrategyExitRules).all()
+    
+    def delete_rules(self, strategy_id: str) -> bool:
+        """Eliminar reglas de una estrategia"""
+        rules = self.db.query(StrategyExitRules).filter(
+            StrategyExitRules.id == strategy_id
+        ).first()
+        
+        if rules:
+            self.db.delete(rules)
+            self.db.commit()
+            logger.info(f"Deleted exit rules for strategy {strategy_id}")
+            return True
+        
+        return False

--- a/tests/test_exit_rules_service.py
+++ b/tests/test_exit_rules_service.py
@@ -1,0 +1,44 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.database import Base
+from app.services.exit_rules_service import ExitRulesService
+from app.models.strategy_exit_rules import StrategyExitRules
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_create_default_rules(db_session):
+    service = ExitRulesService(db_session)
+    
+    rules = service.create_default_rules("test_strategy")
+    
+    assert rules.id == "test_strategy"
+    assert rules.stop_loss_pct == 0.02
+    assert rules.take_profit_pct == 0.04
+    assert rules.use_trailing == True
+
+
+def test_calculate_exit_prices(db_session):
+    service = ExitRulesService(db_session)
+    
+    # Crear reglas de prueba
+    service.create_default_rules("test_strategy")
+    
+    # Calcular precios para entrada en $100
+    result = service.calculate_exit_prices("test_strategy", 100.0, "buy")
+    
+    assert result["entry_price"] == 100.0
+    assert result["stop_loss_price"] == 98.0   # 100 * (1 - 0.02)
+    assert result["take_profit_price"] == 104.0 # 100 * (1 + 0.04)
+    assert result["strategy_id"] == "test_strategy"


### PR DESCRIPTION
## Summary
- implement `ExitRulesService` for retrieving, creating, updating, and calculating strategy exit rules
- expose `ExitRulesService` via service package
- test exit rule defaults and price calculations

## Testing
- `pytest tests/test_exit_rules_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3be8027e883318b05951c6c2ed724