### PR TITLE
Add automatic bracket order handling

### DIFF
--- a/app/core/types.py
+++ b/app/core/types.py
@@ -28,6 +28,7 @@ class OrderStatus(str, Enum):
     CANCELED = "canceled"
     REJECTED = "rejected"
     PENDING_CANCEL = "pending_cancel"
+    PENDING_PARENT = "pending_parent"  # Esperando que se ejecute orden padre
 
 class OrderType(str, Enum):
     MARKET = "market"


### PR DESCRIPTION
## Summary
- extend `OrderManager` with bracket order creation that auto-generates stop loss and take profit orders
- allow `create_order_from_signal` to schedule exit orders
- add `PENDING_PARENT` order status for child orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3bf868e288331a8b13eac1d0319c3