### PR TITLE
Use Decimal for exit price calculations

### DIFF
--- a/app/api/v1/exit_rules.py
+++ b/app/api/v1/exit_rules.py
@@ -7,6 +7,7 @@ from app.services.exit_rules_service import ExitRulesService
 from app.models.strategy_exit_rules import StrategyExitRules
 from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any
+from decimal import Decimal
 import logging
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,7 @@ async def calculate_exit_prices(
         service = ExitRulesService(db)
         result = service.calculate_exit_prices(
             strategy_id,
-            calculation_request.entry_price,
+            Decimal(str(calculation_request.entry_price)),
             calculation_request.side
         )
         
@@ -258,7 +259,7 @@ async def test_exit_rules(
     """Endpoint de testing para probar cálculos de salida"""
     try:
         service = ExitRulesService(db)
-        result = service.calculate_exit_prices(strategy_id, entry_price, side)
+        result = service.calculate_exit_prices(strategy_id, Decimal(str(entry_price)), side)
         
         return {
             "test_scenario": {

--- a/app/api/v1/testing.py
+++ b/app/api/v1/testing.py
@@ -7,6 +7,7 @@ from app.models.user import User
 from app.core.auth import get_current_verified_user, get_admin_user
 from app.execution.testing import ExecutionTester
 from typing import Optional
+from decimal import Decimal
 import logging
 
 logger = logging.getLogger(__name__)
@@ -141,7 +142,7 @@ async def test_full_bracket_flow(
         rules = exit_service.get_rules(strategy_id)
 
         # 2. Calcular precios de salida
-        entry_price = test_request.get("entry_price", 100.0)
+        entry_price = Decimal(str(test_request.get("entry_price", 100.0)))
         exit_calculation = exit_service.calculate_exit_prices(strategy_id, entry_price, "buy")
 
         # 3. Simular creación de señal

--- a/app/execution/order_manager.py
+++ b/app/execution/order_manager.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict, Any, List
 import uuid
 from datetime import datetime
 import logging
+from decimal import Decimal
 from app.services.order_executor import OrderExecutor
 from app.services.exit_rules_service import ExitRulesService
 from app.models.strategy_exit_rules import StrategyExitRules
@@ -202,7 +203,7 @@ class OrderManager:
             exit_rules_service = ExitRulesService(self.db)
             exit_calculation = exit_rules_service.calculate_exit_prices(
                 signal.strategy_id,
-                current_price,
+                Decimal(str(current_price)),
                 signal.action
             )
 

--- a/app/services/exit_rules_service.py
+++ b/app/services/exit_rules_service.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from app.models.strategy_exit_rules import StrategyExitRules
 from typing import Optional, Dict, Any
 import logging
+from decimal import Decimal
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +60,10 @@ class ExitRulesService:
         self.db.refresh(rules)
         return rules
     
-    def calculate_exit_prices(self, strategy_id: str, entry_price: float, side: str = "buy") -> Dict[str, Any]:
+    def calculate_exit_prices(self, strategy_id: str, entry_price: Decimal, side: str = "buy") -> Dict[str, Any]:
         """Calcular precios de salida para una estrategia específica"""
         rules = self.get_rules(strategy_id)
+        entry_price = Decimal(str(entry_price))
         exit_prices = rules.calculate_exit_prices(entry_price, side)
         
         return {

--- a/tests/test_exit_rules_service.py
+++ b/tests/test_exit_rules_service.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import sessionmaker
 from app.database import Base
 from app.services.exit_rules_service import ExitRulesService
 from app.models.strategy_exit_rules import StrategyExitRules
+from decimal import Decimal
 
 
 @pytest.fixture
@@ -36,9 +37,9 @@ def test_calculate_exit_prices(db_session):
     service.create_default_rules("test_strategy")
     
     # Calcular precios para entrada en $100
-    result = service.calculate_exit_prices("test_strategy", 100.0, "buy")
-    
-    assert result["entry_price"] == 100.0
-    assert result["stop_loss_price"] == 98.0   # 100 * (1 - 0.02)
-    assert result["take_profit_price"] == 104.0 # 100 * (1 + 0.04)
+    result = service.calculate_exit_prices("test_strategy", Decimal("100"), "buy")
+
+    assert result["entry_price"] == Decimal("100.00")
+    assert result["stop_loss_price"] == Decimal("98.00")   # 100 * (1 - 0.02)
+    assert result["take_profit_price"] == Decimal("104.00") # 100 * (1 + 0.04)
     assert result["strategy_id"] == "test_strategy"


### PR DESCRIPTION
## Summary
- use `Decimal` in `StrategyExitRules.calculate_exit_prices` with explicit rounding
- propagate `Decimal` handling through service, API, tests, and order manager

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4b3241220833194459d04f4d5d6d8