### PR TITLE
feat: secure strategy exit rules by owner

### DIFF
--- a/app/api/v1/testing.py
+++ b/app/api/v1/testing.py
@@ -139,11 +139,13 @@ async def test_full_bracket_flow(
         from app.services.exit_rules_service import ExitRulesService
         exit_service = ExitRulesService(db)
         strategy_id = test_request.get("strategy_id", "test_strategy")
-        rules = exit_service.get_rules(strategy_id)
+        rules = exit_service.get_rules(strategy_id, current_user.id)
 
         # 2. Calcular precios de salida
         entry_price = Decimal(str(test_request.get("entry_price", 100.0)))
-        exit_calculation = exit_service.calculate_exit_prices(strategy_id, entry_price, "buy")
+        exit_calculation = exit_service.calculate_exit_prices(
+            strategy_id, current_user.id, entry_price, "buy"
+        )
 
         # 3. Simular creación de señal
         from app.models.signal import Signal

--- a/app/execution/bracket_order_integration_test.py
+++ b/app/execution/bracket_order_integration_test.py
@@ -71,7 +71,7 @@ async def test_full_bracket_order_flow(db_session, test_user, test_portfolio, mo
     strategy = Strategy(id=1, name="momentum_test")
     db_session.add(strategy)
     db_session.commit()
-    exit_service.create_default_rules("1")
+    exit_service.create_default_rules("1", user_id=test_user.id)
 
     # Asegurar que estamos dentro del horario de trading
     monkeypatch.setattr(

--- a/app/execution/order_manager.py
+++ b/app/execution/order_manager.py
@@ -203,8 +203,9 @@ class OrderManager:
             exit_rules_service = ExitRulesService(self.db)
             exit_calculation = exit_rules_service.calculate_exit_prices(
                 signal.strategy_id,
+                user_id,
                 Decimal(str(current_price)),
-                signal.action
+                signal.action,
             )
 
             # 3. Crear orden principal (Entry)

--- a/app/execution/trailing_stop_monitor.py
+++ b/app/execution/trailing_stop_monitor.py
@@ -80,7 +80,9 @@ class TrailingStopMonitor:
             
             # 2. Obtener reglas de trailing para la estrategia
             signal = stop_order.signal
-            strategy_rules = self.exit_rules_service.get_rules(signal.strategy_id)
+            strategy_rules = self.exit_rules_service.get_rules(
+                signal.strategy_id, stop_order.user_id
+            )
             
             if not strategy_rules.use_trailing:
                 return {

--- a/app/models/strategy_exit_rules.py
+++ b/app/models/strategy_exit_rules.py
@@ -1,8 +1,6 @@
-from sqlalchemy import Column, String, Float, Boolean, DateTime, UniqueConstraint
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, String, Float, Boolean, DateTime, ForeignKey, Integer
 from app.database import Base
 from app.utils.time import now_eastern
-from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
 
 
@@ -10,6 +8,7 @@ class StrategyExitRules(Base):
     __tablename__ = "strategy_exit_rules"
 
     id = Column(String(50), primary_key=True, index=True)  # strategy_id
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     
     # Porcentajes para Stop Loss y Take Profit
     stop_loss_pct = Column(Float, nullable=False, default=0.02)  # 2%

--- a/tests/test_exit_rules_api.py
+++ b/tests/test_exit_rules_api.py
@@ -17,7 +17,7 @@ client = TestClient(app)
 
 
 @pytest.fixture
-def auth_headers():
+def client_and_db():
     engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
     TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     Base.metadata.create_all(bind=engine)
@@ -29,45 +29,51 @@ def auth_headers():
         finally:
             pass
 
-    def override_user():
-        return User(id=1, email="test@example.com", username="test", password_hash="x", is_verified=True)
-
     app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_current_verified_user] = override_user
 
-    yield {"Authorization": "Bearer test"}
+    yield client
 
     db.close()
     app.dependency_overrides.clear()
 
 
-def test_create_exit_rules(auth_headers):
+def get_headers():
+    return {"Authorization": "Bearer test"}
+
+
+def user_factory(user_id: int) -> User:
+    return User(id=user_id, email=f"user{user_id}@example.com", username=f"user{user_id}", password_hash="x", is_verified=True)
+
+
+def test_create_exit_rules(client_and_db):
+    client = client_and_db
+
+    app.dependency_overrides[get_current_verified_user] = lambda: user_factory(1)
+
     payload = {
         "strategy_id": "test_strategy",
         "stop_loss_pct": 0.03,
         "take_profit_pct": 0.06,
         "trailing_stop_pct": 0.02,
         "use_trailing": True,
-        "risk_reward_ratio": 2.0
+        "risk_reward_ratio": 2.0,
     }
 
-    response = client.post(
-        "/api/v1/exit-rules/test_strategy",
-        json=payload,
-        headers=auth_headers
-    )
-
+    response = client.post("/api/v1/exit-rules/test_strategy", json=payload, headers=get_headers())
     assert response.status_code == 200
     data = response.json()
     assert data["strategy_id"] == "test_strategy"
     assert data["stop_loss_pct"] == 0.03
 
 
-def test_calculate_exit_prices(auth_headers):
+def test_calculate_exit_prices(client_and_db):
+    client = client_and_db
+    app.dependency_overrides[get_current_verified_user] = lambda: user_factory(1)
+
     response = client.post(
         "/api/v1/exit-rules/test_strategy/calculate",
         json={"entry_price": 100.0, "side": "buy"},
-        headers=auth_headers
+        headers=get_headers(),
     )
 
     assert response.status_code == 200
@@ -75,3 +81,38 @@ def test_calculate_exit_prices(auth_headers):
     assert data["entry_price"] == 100.0
     assert "stop_loss_price" in data
     assert "take_profit_price" in data
+
+
+def test_authorization_get_and_update(client_and_db):
+    client = client_and_db
+
+    # Owner creates rules
+    app.dependency_overrides[get_current_verified_user] = lambda: user_factory(1)
+    client.post(
+        "/api/v1/exit-rules/test_strategy",
+        json={
+            "strategy_id": "test_strategy",
+            "stop_loss_pct": 0.03,
+            "take_profit_pct": 0.06,
+            "trailing_stop_pct": 0.02,
+            "use_trailing": True,
+            "risk_reward_ratio": 2.0,
+        },
+        headers=get_headers(),
+    )
+
+    # Owner can retrieve
+    response = client.get("/api/v1/exit-rules/test_strategy", headers=get_headers())
+    assert response.status_code == 200
+
+    # Another user cannot retrieve or update
+    app.dependency_overrides[get_current_verified_user] = lambda: user_factory(2)
+    response = client.get("/api/v1/exit-rules/test_strategy", headers=get_headers())
+    assert response.status_code == 403 or response.status_code == 404
+
+    response = client.put(
+        "/api/v1/exit-rules/test_strategy",
+        json={"stop_loss_pct": 0.05},
+        headers=get_headers(),
+    )
+    assert response.status_code == 403 or response.status_code == 404

--- a/tests/test_exit_rules_service.py
+++ b/tests/test_exit_rules_service.py
@@ -1,4 +1,6 @@
 import pytest
+import pytest
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from app.database import Base
@@ -21,9 +23,9 @@ def db_session():
 
 def test_create_default_rules(db_session):
     service = ExitRulesService(db_session)
-    
-    rules = service.create_default_rules("test_strategy")
-    
+
+    rules = service.create_default_rules("test_strategy", user_id=1)
+
     assert rules.id == "test_strategy"
     assert rules.stop_loss_pct == 0.02
     assert rules.take_profit_pct == 0.04
@@ -32,12 +34,12 @@ def test_create_default_rules(db_session):
 
 def test_calculate_exit_prices(db_session):
     service = ExitRulesService(db_session)
-    
+
     # Crear reglas de prueba
-    service.create_default_rules("test_strategy")
-    
+    service.create_default_rules("test_strategy", user_id=1)
+
     # Calcular precios para entrada en $100
-    result = service.calculate_exit_prices("test_strategy", Decimal("100"), "buy")
+    result = service.calculate_exit_prices("test_strategy", 1, Decimal("100"), "buy")
 
     assert result["entry_price"] == Decimal("100.00")
     assert result["stop_loss_price"] == Decimal("98.00")   # 100 * (1 - 0.02)


### PR DESCRIPTION
## Summary
- tie StrategyExitRules to a user owner and enforce permission checks
- ensure exit rule endpoints only allow access by the owning user
- cover exit rule authorization with new positive and negative tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4ba5eac70833193a667209feba662