### PR TITLE
Handle price retrieval failures in bracket order creation

### DIFF
--- a/app/execution/bracket_order_integration_test.py
+++ b/app/execution/bracket_order_integration_test.py
@@ -79,6 +79,12 @@ async def test_full_bracket_order_flow(db_session, test_user, test_portfolio, mo
         lambda: datetime(2024, 1, 2, 10, 0, tzinfo=ZoneInfo("America/New_York")),
     )
 
+    # Stub current price retrieval to avoid external API calls
+    monkeypatch.setattr(
+        "app.execution.order_manager.OrderManager._get_current_price",
+        lambda self, symbol: 100.0,
+    )
+
     # 2. Crear webhook de TradingView
     webhook_data = TradingViewWebhook(
         symbol="AAPL",

--- a/tests/test_bracket_order_price_error.py
+++ b/tests/test_bracket_order_price_error.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.execution.order_manager import OrderManager, PriceUnavailableError
+from app.models.signal import Signal
+
+
+def test_create_bracket_order_aborts_on_price_error(monkeypatch):
+    om = OrderManager(db=None)
+
+    def fake_get_current_price(symbol):
+        raise PriceUnavailableError("no price")
+
+    called = {"flag": False}
+
+    def fake_create_order_from_signal(signal, user_id, portfolio_id):
+        called["flag"] = True
+        return None
+
+    monkeypatch.setattr(om, "_get_current_price", fake_get_current_price)
+    monkeypatch.setattr(om, "create_order_from_signal", fake_create_order_from_signal)
+
+    signal = Signal(symbol="AAPL", action="buy", strategy_id="s")
+
+    result = om.create_bracket_order_from_signal(signal, user_id=1, portfolio_id=1)
+
+    assert result["status"] == "error"
+    assert "price" in result["message"].lower()
+    assert called["flag"] is False


### PR DESCRIPTION
## Summary
- Raise `PriceUnavailableError` when unable to fetch live price instead of using a placeholder
- Catch price retrieval errors in `create_bracket_order_from_signal` to abort bracket creation
- Stub price lookup in integration test and add unit test verifying cancellation on price errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c3f9621883319b1b24707176ca8a