### PR TITLE
Ensure bracket order rollback on exit order failure

### DIFF
--- a/tests/test_bracket_order_rollback.py
+++ b/tests/test_bracket_order_rollback.py
@@ -1,0 +1,58 @@
+import pytest
+from decimal import Decimal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.user import User
+from app.models.signal import Signal
+from app.models.order import Order
+from app.execution.order_manager import OrderManager
+from app.services.exit_rules_service import ExitRulesService
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_exit_order_failure_rolls_back_main_order(db_session, monkeypatch):
+    # Create required user and signal
+    user = User(id=1, email="test@example.com", username="user", password_hash="pwd")
+    db_session.add(user)
+    signal = Signal(id=1, symbol="AAPL", action="buy", strategy_id="strat", user_id=user.id)
+    db_session.add(signal)
+    db_session.commit()
+
+    om = OrderManager(db_session)
+
+    # Mock current price and exit rule calculation
+    monkeypatch.setattr(om, "_get_current_price", lambda symbol: 100.0)
+
+    def fake_calc(self, strategy_id, user_id, price, action):
+        return {
+            "entry_price": Decimal("100"),
+            "stop_loss_price": Decimal("95"),
+            "take_profit_price": Decimal("105"),
+        }
+
+    monkeypatch.setattr(ExitRulesService, "calculate_exit_prices", fake_calc)
+
+    # Force _create_exit_orders to fail
+    def fail_exit_orders(main_order, exit_calculation, strategy_id, commit=False):
+        raise Exception("failure creating exits")
+
+    monkeypatch.setattr(om, "_create_exit_orders", fail_exit_orders)
+
+    result = om.create_bracket_order_from_signal(signal, user_id=user.id, portfolio_id=None)
+
+    assert result["status"] == "error"
+    # No orders should be persisted due to rollback
+    assert db_session.query(Order).count() == 0


### PR DESCRIPTION
## Summary
- Wrap bracket order creation in a database transaction
- Roll back main order if exit order creation fails
- Add test to simulate exit order failure and verify rollback

## Testing
- `pytest tests/test_bracket_order_price_error.py tests/test_bracket_order_rollback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c65aad8083319048ae428edd15f1