### PR TITLE
Add timeout handling and logging for Alpaca client

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     alpaca_secret_key: Optional[str] = None
     alpaca_base_url: str = "https://paper-api.alpaca.markets"
     alpaca_paper: bool = True
+    alpaca_timeout: float = 5.0
 
     # Active broker identifier
     active_broker: Optional[str] = "alpaca"


### PR DESCRIPTION
## Summary
- add `alpaca_timeout` setting and use logging instead of print
- wrap Alpaca client `submit_order` and `get_latest_trade` in try/except with configurable timeout
- cover timeout scenarios with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4cfdc861c8331925f95bc892fc1fc