### PR TITLE
feat: add notes column to orders

### DIFF
--- a/alembic/versions/8a51a7e87355_add_notes_column_to_orders.py
+++ b/alembic/versions/8a51a7e87355_add_notes_column_to_orders.py
@@ -1,0 +1,25 @@
+"""add notes column to orders
+
+Revision ID: 8a51a7e87355
+Revises: fe8c04b7556e
+Create Date: 2025-11-13 00:00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '8a51a7e87355'
+down_revision: Union[str, Sequence[str], None] = 'fe8c04b7556e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('orders', sa.Column('notes', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('orders', 'notes')

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -53,6 +53,7 @@ class Order(Base):
     # Retry y error handling
     retry_count = Column(Integer, default=0, nullable=False)
     last_error = Column(Text, nullable=True)
+    notes = Column(Text, nullable=True)
     
     # Time in force
     time_in_force = Column(String(10), default="day", nullable=False)


### PR DESCRIPTION
## Summary
- add optional notes field to Order model
- provide alembic migration for new notes column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f4a266ec83318cdbc24be9d8d804