### PR TITLE
feat: add notes field to signals

### DIFF
--- a/alembic/versions/e819ab670950_add_notes_column_to_signals.py
+++ b/alembic/versions/e819ab670950_add_notes_column_to_signals.py
@@ -1,0 +1,25 @@
+"""add notes column to signals
+
+Revision ID: e819ab670950
+Revises: 8a51a7e87355
+Create Date: 2025-09-01 01:26:45
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e819ab670950'
+down_revision: Union[str, Sequence[str], None] = '8a51a7e87355'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('signals', sa.Column('notes', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('signals', 'notes')

--- a/app/models/signal.py
+++ b/app/models/signal.py
@@ -20,6 +20,7 @@ class Signal(Base):
     processed = Column(Boolean, default=False)
     status = Column(String(20), default="pending")  # pending, processed, error
     error_message = Column(Text, nullable=True)
+    notes = Column(Text, nullable=True)
 
     # Campos para análisis avanzado
     reason = Column(String(50), nullable=True)  # fibonacci_entry, fibonacci_exit, trailing_stop

--- a/tests/test_signal_notes.py
+++ b/tests/test_signal_notes.py
@@ -1,0 +1,21 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.signal import Signal
+
+
+def test_signal_notes_persist():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    signal = Signal(symbol="AAPL", action="buy", strategy_id="strat", notes="test note")
+    session.add(signal)
+    session.commit()
+
+    fetched = session.query(Signal).filter_by(id=signal.id).first()
+    assert fetched is not None
+    assert fetched.notes == "test note"


### PR DESCRIPTION
## Summary
- add optional notes text to Signal model
- migrate database to include notes on signals
- test persistence of signal notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5ff7b748331b4d3f7edb3a6e2b7