### PR TITLE
Ensure shared DB session for bracket order execution

### DIFF
--- a/app/execution/bracket_order_processor.py
+++ b/app/execution/bracket_order_processor.py
@@ -18,7 +18,7 @@ class BracketOrderProcessor:
     
     def __init__(self, db: Session):
         self.db = db
-        self.executor = OrderExecutor()
+        self.executor = OrderExecutor(self.db)
     
     async def activate_bracket_orders(self, parent_order_id: int) -> Dict[str, Any]:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,30 @@
 import sys
+import os
+import types
+import importlib.util
 from pathlib import Path
 
 # Ensure project root is in sys.path for tests
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# Use in-memory SQLite database for tests
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+# Create lightweight app.execution package to avoid heavy dependencies
+execution_pkg = types.ModuleType("app.execution")
+sys.modules.setdefault("app.execution", execution_pkg)
+
+
+def _load_module(fullname: str, path: str) -> None:
+    spec = importlib.util.spec_from_file_location(fullname, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    sys.modules[fullname] = module
+
+
+_load_module("app.execution.order_executor", str(ROOT / "app/execution/order_executor.py"))
+_load_module(
+    "app.execution.bracket_order_processor", str(ROOT / "app/execution/bracket_order_processor.py")
+)

--- a/tests/test_bracket_processor_session.py
+++ b/tests/test_bracket_processor_session.py
@@ -1,0 +1,80 @@
+import pytest
+from decimal import Decimal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.user import User
+from app.models.signal import Signal
+from app.models.order import Order
+from app.core.types import OrderStatus
+from app.execution.bracket_order_processor import BracketOrderProcessor
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_bracket_processor_uses_same_session(db_session):
+    user = User(id=1, email="test@example.com", username="user", password_hash="pwd")
+    db_session.add(user)
+    signal = Signal(id=1, symbol="AAPL", action="buy", strategy_id="strat", user_id=user.id)
+    db_session.add(signal)
+    db_session.commit()
+
+    parent_order = Order(
+        client_order_id="PARENT",
+        symbol="AAPL",
+        side="buy",
+        quantity=Decimal("10"),
+        order_type="market",
+        status=OrderStatus.FILLED,
+        is_bracket_parent=True,
+        signal_id=signal.id,
+        user_id=user.id,
+    )
+    db_session.add(parent_order)
+    db_session.commit()
+
+    child_order = Order(
+        client_order_id="CHILD",
+        symbol="AAPL",
+        side="sell",
+        quantity=Decimal("10"),
+        order_type="limit",
+        limit_price=Decimal("200"),
+        status=OrderStatus.PENDING_PARENT,
+        parent_order_id=parent_order.id,
+        signal_id=signal.id,
+        user_id=user.id,
+    )
+    db_session.add(child_order)
+    db_session.commit()
+
+    processor = BracketOrderProcessor(db_session)
+    child_id = child_order.id
+    parent_id = parent_order.id
+
+    async def fake_execute_single_order(self, **_):
+        parent = self.db.query(Order).filter(Order.id == parent_id).one()
+        parent.notes = "updated"
+        return {"status": "success", "broker_order_id": "SIM-TEST"}
+
+    processor.executor.execute_single_order = fake_execute_single_order.__get__(processor.executor, type(processor.executor))
+
+    await processor.activate_bracket_orders(parent_order.id)
+
+    parent_ref = db_session.query(Order).filter(Order.id == parent_id).one()
+    child_ref = db_session.query(Order).filter(Order.id == child_id).one()
+
+    assert parent_ref.notes == "updated"
+    assert child_ref.status == OrderStatus.SENT


### PR DESCRIPTION
## Summary
- Create `OrderExecutor` with the same database session in `BracketOrderProcessor`
- Configure tests to preload execution modules and use in-memory SQLite
- Add regression test verifying state updates occur within a shared session

## Testing
- `DATABASE_URL=sqlite:///:memory: python3 -m pytest tests/test_bracket_processor_session.py tests/test_bracket_status_filled_quantity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4fb4042248331ab92f923d4192fb8