### PR TITLE
Abort bracket creation on invalid current price

### DIFF
--- a/app/execution/order_manager.py
+++ b/app/execution/order_manager.py
@@ -383,7 +383,12 @@ class OrderManager:
         try:
             from app.integrations import broker_client
             trade = broker_client.get_latest_trade(symbol)
-            return float(getattr(trade, "price", 0.0))
+            price = float(getattr(trade, "price", 0.0))
+            if price <= 0:
+                raise PriceUnavailableError(f"Current price unavailable for {symbol}")
+            return price
+        except PriceUnavailableError:
+            raise
         except Exception as e:
             logger.error(f"Error getting current price for {symbol}: {e}")
             raise PriceUnavailableError(f"Current price unavailable for {symbol}") from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 
 # Create lightweight app.execution package to avoid heavy dependencies
 execution_pkg = types.ModuleType("app.execution")
+execution_pkg.__path__ = []
 sys.modules.setdefault("app.execution", execution_pkg)
 
 
@@ -28,3 +29,4 @@ _load_module("app.execution.order_executor", str(ROOT / "app/execution/order_exe
 _load_module(
     "app.execution.bracket_order_processor", str(ROOT / "app/execution/bracket_order_processor.py")
 )
+_load_module("app.execution.order_manager", str(ROOT / "app/execution/order_manager.py"))

--- a/tests/test_bracket_order_price_error.py
+++ b/tests/test_bracket_order_price_error.py
@@ -26,3 +26,33 @@ def test_create_bracket_order_aborts_on_price_error(monkeypatch):
     assert result["status"] == "error"
     assert "price" in result["message"].lower()
     assert called["flag"] is False
+
+
+def test_create_bracket_order_aborts_on_zero_price(monkeypatch):
+    om = OrderManager(db=None)
+
+    class DummyTrade:
+        price = 0
+
+    def fake_get_latest_trade(symbol):
+        return DummyTrade()
+
+    called = {"flag": False}
+
+    def fake_create_order_from_signal(signal, user_id, portfolio_id, **kwargs):
+        called["flag"] = True
+        return None
+
+    monkeypatch.setattr(
+        "app.integrations.broker_client.get_latest_trade",
+        fake_get_latest_trade,
+    )
+    monkeypatch.setattr(om, "create_order_from_signal", fake_create_order_from_signal)
+
+    signal = Signal(symbol="AAPL", action="buy", strategy_id="s")
+
+    result = om.create_bracket_order_from_signal(signal, user_id=1, portfolio_id=1)
+
+    assert result["status"] == "error"
+    assert "price" in result["message"].lower()
+    assert called["flag"] is False


### PR DESCRIPTION
## Summary
- Validate `_get_current_price` returns a positive price, otherwise raise `PriceUnavailableError`
- Ensure tests cover zero-price responses from `get_latest_trade`
- Load `OrderManager` in tests' lightweight `app.execution` package

## Testing
- `pytest tests/test_bracket_order_price_error.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.execution.bracket_order_integration_test')*

------
https://chatgpt.com/codex/tasks/task_e_68b4fcc636f88331bac9c56238645248