### PR TITLE
Add advanced analytics chart components

### DIFF
--- a/frontend/src/components/analytics/EquityCurve.tsx
+++ b/frontend/src/components/analytics/EquityCurve.tsx
@@ -1,0 +1,318 @@
+import React, { useState, useEffect } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  Area,
+  AreaChart,
+} from 'recharts';
+import { TrendingUp, TrendingDown, AlertTriangle } from 'lucide-react';
+import api from '../../services/api';
+
+interface EquityCurveData {
+  date: string;
+  equity: number;
+  drawdown: number;
+  trade_id: number;
+  symbol: string;
+  pnl: number;
+}
+
+interface DrawdownPeriod {
+  start_date: string;
+  end_date: string;
+  start_equity: number;
+  end_equity: number;
+  max_drawdown: number;
+  duration_days: number;
+}
+
+interface EquityCurveProps {
+  timeframe?: string;
+  portfolioId?: number;
+  height?: number;
+}
+
+const EquityCurve: React.FC<EquityCurveProps> = ({
+  timeframe = '3M',
+  portfolioId,
+  height = 400,
+}) => {
+  const [data, setData] = useState<EquityCurveData[]>([]);
+  const [drawdownPeriods, setDrawdownPeriods] = useState<DrawdownPeriod[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showDrawdown, setShowDrawdown] = useState(true);
+
+  useEffect(() => {
+    fetchEquityCurveData();
+  }, [timeframe, portfolioId]);
+
+  const fetchEquityCurveData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await api.analytics.getEquityCurve(timeframe, portfolioId);
+
+      const formattedData = response.equity_curve.map((point: EquityCurveData) => ({
+        ...point,
+        date: new Date(point.date).toLocaleDateString(),
+        equity: Math.round(point.equity * 100) / 100,
+        drawdown: Math.round(point.drawdown * 100) / 100,
+      }));
+
+      setData(formattedData);
+      setDrawdownPeriods(response.drawdown_periods || []);
+    } catch (err) {
+      console.error('Error fetching equity curve:', err);
+      setError('Error loading equity curve data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatCurrency = (value: number): string => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(value);
+  };
+
+  const formatTooltip = (value: any, name: string) => {
+    if (name === 'equity') {
+      return [formatCurrency(value), 'Equity'];
+    }
+    if (name === 'drawdown') {
+      return [`${value}%`, 'Drawdown'];
+    }
+    return [value, name];
+  };
+
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length > 0) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-white p-3 border border-gray-200 rounded-lg shadow-sm">
+          <p className="font-medium text-gray-900">{label}</p>
+          <p className="text-blue-600">
+            <span className="font-medium">Equity:</span> {formatCurrency(data.equity)}
+          </p>
+          {showDrawdown && (
+            <p className="text-red-600">
+              <span className="font-medium">Drawdown:</span> {data.drawdown}%
+            </p>
+          )}
+          <p className="text-gray-600 text-sm">
+            <span className="font-medium">Trade:</span> {data.symbol} ({formatCurrency(data.pnl)})
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <div className="flex items-center">
+          <AlertTriangle className="h-5 w-5 text-red-500 mr-2" />
+          <span className="text-red-700">{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="text-center text-gray-500 py-8">
+        No equity curve data available for the selected period
+      </div>
+    );
+  }
+
+  const finalEquity = data[data.length - 1]?.equity || 0;
+  const initialEquity = data[0]?.equity || 0;
+  const totalReturn = finalEquity - initialEquity;
+  const totalReturnPercent =
+    initialEquity !== 0 ? (totalReturn / Math.abs(initialEquity)) * 100 : 0;
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Equity Curve</h3>
+          <div className="flex items-center space-x-4 mt-2">
+            <div className="flex items-center">
+              {totalReturn >= 0 ? (
+                <TrendingUp className="h-4 w-4 text-green-500 mr-1" />
+              ) : (
+                <TrendingDown className="h-4 w-4 text-red-500 mr-1" />
+              )}
+              <span
+                className={`text-sm font-medium ${
+                  totalReturn >= 0 ? 'text-green-600' : 'text-red-600'
+                }`}
+              >
+                {formatCurrency(totalReturn)} ({totalReturnPercent >= 0 ? '+' : ''}
+                {totalReturnPercent.toFixed(1)}%)
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center space-x-3">
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              checked={showDrawdown}
+              onChange={(e) => setShowDrawdown(e.target.checked)}
+              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="ml-2 text-sm text-gray-700">Show Drawdown</span>
+          </label>
+        </div>
+      </div>
+
+      {drawdownPeriods.length > 0 && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+          <div className="flex items-center mb-2">
+            <AlertTriangle className="h-4 w-4 text-red-500 mr-2" />
+            <span className="text-sm font-medium text-red-700">
+              {drawdownPeriods.length} Significant Drawdown Period
+              {drawdownPeriods.length > 1 ? 's' : ''}
+            </span>
+          </div>
+          <div className="text-xs text-red-600 space-y-1">
+            {drawdownPeriods.slice(0, 3).map((period, index) => (
+              <div key={index}>
+                {new Date(period.start_date).toLocaleDateString()} -{' '}
+                {period.end_date
+                  ? new Date(period.end_date).toLocaleDateString()
+                  : 'Ongoing'}: <span className="font-medium">
+                  {period.max_drawdown.toFixed(1)}%
+                </span>{' '}
+                ({period.duration_days} days)
+              </div>
+            ))}
+            {drawdownPeriods.length > 3 && (
+              <div className="text-gray-500">+{drawdownPeriods.length - 3} more periods</div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div style={{ height: height }}>
+        <ResponsiveContainer width="100%" height="100%">
+          {showDrawdown ? (
+            <div className="relative w-full h-full">
+              <ResponsiveContainer width="100%" height="70%">
+                <LineChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 12 }}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis tick={{ fontSize: 12 }} tickFormatter={formatCurrency} />
+                  <Tooltip content={<CustomTooltip />} formatter={formatTooltip} />
+                  <Line
+                    type="monotone"
+                    dataKey="equity"
+                    stroke="#2563eb"
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 4, stroke: '#2563eb', strokeWidth: 2 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+
+              <ResponsiveContainer width="100%" height="30%">
+                <AreaChart data={data} margin={{ top: 0, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 10 }}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis
+                    tick={{ fontSize: 10 }}
+                    domain={['dataMin', 0]}
+                    tickFormatter={(value) => `${value}%`}
+                  />
+                  <Tooltip
+                    formatter={(value: any) => [`${value}%`, 'Drawdown']}
+                    labelStyle={{ fontSize: '12px' }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="drawdown"
+                    stroke="#dc2626"
+                    fill="#dc2626"
+                    fillOpacity={0.2}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <LineChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <XAxis dataKey="date" tick={{ fontSize: 12 }} interval="preserveStartEnd" />
+              <YAxis tick={{ fontSize: 12 }} tickFormatter={formatCurrency} />
+              <Tooltip content={<CustomTooltip />} formatter={formatTooltip} />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="equity"
+                stroke="#2563eb"
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 6, stroke: '#2563eb', strokeWidth: 2 }}
+                name="Portfolio Equity"
+              />
+            </LineChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mt-4 pt-4 border-t border-gray-200">
+        <div className="text-center">
+          <p className="text-2xl font-bold text-blue-600">
+            {formatCurrency(finalEquity)}
+          </p>
+          <p className="text-sm text-gray-500">Current Equity</p>
+        </div>
+        <div className="text-center">
+          <p className="text-2xl font-bold text-green-600">
+            {data.length > 0 ? data.length : 0}
+          </p>
+          <p className="text-sm text-gray-500">Total Trades</p>
+        </div>
+        <div className="text-center">
+          <p className="text-2xl font-bold text-red-600">
+            {Math.min(...data.map((d) => d.drawdown)).toFixed(1)}%
+          </p>
+          <p className="text-sm text-gray-500">Max Drawdown</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EquityCurve;
+

--- a/frontend/src/components/analytics/MonthlyHeatmap.tsx
+++ b/frontend/src/components/analytics/MonthlyHeatmap.tsx
@@ -1,0 +1,218 @@
+import React, { useState, useEffect } from 'react';
+import { Calendar, TrendingUp, TrendingDown } from 'lucide-react';
+import api from '../../services/api';
+
+interface MonthlyReturn {
+  month: string;
+  pnl: number;
+  trades: number;
+  win_rate: number;
+}
+
+interface MonthlyHeatmapProps {
+  portfolioId?: number;
+}
+
+const MonthlyHeatmap: React.FC<MonthlyHeatmapProps> = ({ portfolioId }) => {
+  const [monthlyData, setMonthlyData] = useState<MonthlyReturn[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchMonthlyData();
+  }, [portfolioId]);
+
+  const fetchMonthlyData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await api.analytics.getMonthlyPerformance(portfolioId);
+      setMonthlyData(response.monthly_returns || []);
+    } catch (err) {
+      console.error('Error fetching monthly data:', err);
+      setError('Error loading monthly performance data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatCurrency = (amount: number): string => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  };
+
+  const getColorIntensity = (pnl: number, maxAbsPnl: number): string => {
+    if (pnl === 0) return 'bg-gray-100';
+
+    const intensity = Math.abs(pnl) / maxAbsPnl;
+    const level = Math.min(Math.floor(intensity * 5) + 1, 5);
+
+    if (pnl > 0) {
+      return `bg-green-${level * 100}`;
+    } else {
+      return `bg-red-${level * 100}`;
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error || !monthlyData || monthlyData.length === 0) {
+    return (
+      <div className="bg-white p-6 rounded-lg shadow-sm border">
+        <div className="text-center text-gray-500 py-8">
+          {error || 'No monthly performance data available'}
+        </div>
+      </div>
+    );
+  }
+
+  const totalPnl = monthlyData.reduce((sum, month) => sum + month.pnl, 0);
+  const avgMonthlyReturn = totalPnl / monthlyData.length;
+  const positiveMonths = monthlyData.filter((m) => m.pnl > 0).length;
+  const winRate = (positiveMonths / monthlyData.length) * 100;
+  const maxAbsPnl = Math.max(...monthlyData.map((m) => Math.abs(m.pnl)));
+
+  const yearMonthData: { [year: string]: { [month: string]: MonthlyReturn } } = {};
+  monthlyData.forEach((data) => {
+    const [year, month] = data.month.split('-');
+    if (!yearMonthData[year]) {
+      yearMonthData[year] = {};
+    }
+    yearMonthData[year][month] = data;
+  });
+
+  const months = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
+  const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <div className="flex items-center">
+            <Calendar className="h-5 w-5 text-blue-600 mr-2" />
+            <h3 className="text-lg font-semibold text-gray-900">Monthly Performance Heatmap</h3>
+          </div>
+          <p className="text-sm text-gray-600 mt-1">Monthly P&L performance overview</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <div className="text-center p-3 bg-blue-50 rounded-lg">
+          <p className="text-xl font-bold text-blue-600">{formatCurrency(totalPnl)}</p>
+          <p className="text-sm text-gray-600">Total P&L</p>
+        </div>
+        <div className="text-center p-3 bg-green-50 rounded-lg">
+          <p className="text-xl font-bold text-green-600">{formatCurrency(avgMonthlyReturn)}</p>
+          <p className="text-sm text-gray-600">Avg Monthly</p>
+        </div>
+        <div className="text-center p-3 bg-purple-50 rounded-lg">
+          <p className="text-xl font-bold text-purple-600">{positiveMonths}</p>
+          <p className="text-sm text-gray-600">Positive Months</p>
+        </div>
+        <div className="text-center p-3 bg-gray-50 rounded-lg">
+          <p className="text-xl font-bold text-gray-600">{winRate.toFixed(1)}%</p>
+          <p className="text-sm text-gray-600">Monthly Win Rate</p>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <div className="min-w-full">
+          <div className="flex mb-2">
+            <div className="w-16"></div>
+            {monthNames.map((month) => (
+              <div key={month} className="w-20 text-center text-sm font-medium text-gray-600">
+                {month}
+              </div>
+            ))}
+          </div>
+
+          {Object.keys(yearMonthData)
+            .sort()
+            .map((year) => (
+              <div key={year} className="flex items-center mb-2">
+                <div className="w-16 text-sm font-medium text-gray-700 text-right pr-3">
+                  {year}
+                </div>
+                {months.map((month) => {
+                  const monthData = yearMonthData[year][month];
+                  const colorClass = monthData
+                    ? getColorIntensity(monthData.pnl, maxAbsPnl)
+                    : 'bg-gray-100';
+
+                  return (
+                    <div
+                      key={month}
+                      className={`w-20 h-16 mr-1 rounded-lg border border-gray-200 ${colorClass} flex flex-col items-center justify-center cursor-pointer hover:ring-2 hover:ring-blue-300 transition-all duration-200 ${
+                        monthData ? 'hover:shadow-md' : ''
+                      }`}
+                      title={
+                        monthData
+                          ? `${year}-${month}: ${formatCurrency(monthData.pnl)} (${monthData.trades} trades, ${monthData.win_rate}% WR)`
+                          : `${year}-${month}: No data`
+                      }
+                    >
+                      {monthData && (
+                        <>
+                          <div className="flex items-center">
+                            {monthData.pnl >= 0 ? (
+                              <TrendingUp className="h-3 w-3 text-green-700" />
+                            ) : (
+                              <TrendingDown className="h-3 w-3 text-red-700" />
+                            )}
+                          </div>
+                          <div
+                            className={`text-xs font-medium mt-1 ${
+                              monthData.pnl >= 0 ? 'text-green-800' : 'text-red-800'
+                            }`}
+                          >
+                            {Math.abs(monthData.pnl) >= 1000
+                              ? `${(monthData.pnl / 1000).toFixed(1)}k`
+                              : monthData.pnl.toFixed(0)}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between mt-6 pt-4 border-t border-gray-200">
+        <div className="text-sm text-gray-600">Hover over cells for detailed information</div>
+        <div className="flex items-center space-x-2">
+          <span className="text-xs text-gray-500">Loss</span>
+          <div className="flex space-x-1">
+            <div className="w-3 h-3 bg-red-500 rounded"></div>
+            <div className="w-3 h-3 bg-red-400 rounded"></div>
+            <div className="w-3 h-3 bg-red-300 rounded"></div>
+            <div className="w-3 h-3 bg-red-200 rounded"></div>
+            <div className="w-3 h-3 bg-red-100 rounded"></div>
+            <div className="w-3 h-3 bg-gray-100 rounded border"></div>
+            <div className="w-3 h-3 bg-green-100 rounded"></div>
+            <div className="w-3 h-3 bg-green-200 rounded"></div>
+            <div className="w-3 h-3 bg-green-300 rounded"></div>
+            <div className="w-3 h-3 bg-green-400 rounded"></div>
+            <div className="w-3 h-3 bg-green-500 rounded"></div>
+          </div>
+          <span className="text-xs text-gray-500">Profit</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MonthlyHeatmap;
+

--- a/frontend/src/components/analytics/TradeDistribution.tsx
+++ b/frontend/src/components/analytics/TradeDistribution.tsx
@@ -1,0 +1,241 @@
+import React, { useState, useEffect } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  PieChart,
+  Pie,
+  Legend,
+} from 'recharts';
+import { BarChart3, PieChart as PieChartIcon } from 'lucide-react';
+import api from '../../services/api';
+
+interface TradeDistributionData {
+  win_distribution: Array<{
+    range: string;
+    count: number;
+    percentage: number;
+  }>;
+  loss_distribution: Array<{
+    range: string;
+    count: number;
+    percentage: number;
+  }>;
+  total_winners: number;
+  total_losers: number;
+  avg_winner: number;
+  avg_loser: number;
+}
+
+interface TradeDistributionProps {
+  timeframe?: string;
+  portfolioId?: number;
+}
+
+const TradeDistribution: React.FC<TradeDistributionProps> = ({
+  timeframe = '3M',
+  portfolioId,
+}) => {
+  const [distribution, setDistribution] = useState<TradeDistributionData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [viewType, setViewType] = useState<'bar' | 'pie'>('bar');
+
+  useEffect(() => {
+    fetchTradeDistribution();
+  }, [timeframe, portfolioId]);
+
+  const fetchTradeDistribution = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await api.analytics.getTradeAnalytics(timeframe, portfolioId);
+      setDistribution(response.trade_distribution);
+    } catch (err) {
+      console.error('Error fetching trade distribution:', err);
+      setError('Error loading trade distribution data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatCurrency = (amount: number): string => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error || !distribution) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <span className="text-red-700">{error || 'No data available'}</span>
+      </div>
+    );
+  }
+
+  const combinedData: Array<{ range: string; winners: number; losers: number; winPercent: number; lossPercent: number }> = [];
+  const maxWinLength = Math.max(
+    distribution.win_distribution.length,
+    distribution.loss_distribution.length,
+  );
+
+  for (let i = 0; i < maxWinLength; i++) {
+    const winData = distribution.win_distribution[i];
+    const lossData = distribution.loss_distribution[i];
+
+    combinedData.push({
+      range: winData?.range || lossData?.range || `Range ${i + 1}`,
+      winners: winData?.count || 0,
+      losers: -(lossData?.count || 0),
+      winPercent: winData?.percentage || 0,
+      lossPercent: lossData?.percentage || 0,
+    });
+  }
+
+  const pieData = [
+    {
+      name: 'Winning Trades',
+      value: distribution.total_winners,
+      color: '#10b981',
+    },
+    {
+      name: 'Losing Trades',
+      value: distribution.total_losers,
+      color: '#ef4444',
+    },
+  ];
+
+  const COLORS = ['#10b981', '#ef4444'];
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Trade Distribution</h3>
+          <p className="text-sm text-gray-600">
+            Distribution of winning and losing trades by P&L range
+          </p>
+        </div>
+
+        <div className="flex bg-gray-100 rounded-lg p-1">
+          <button
+            onClick={() => setViewType('bar')}
+            className={`flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+              viewType === 'bar'
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            <BarChart3 className="h-4 w-4 mr-2" />
+            Bar Chart
+          </button>
+          <button
+            onClick={() => setViewType('pie')}
+            className={`flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+              viewType === 'pie'
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            <PieChartIcon className="h-4 w-4 mr-2" />
+            Pie Chart
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <div className="text-center p-3 bg-green-50 rounded-lg">
+          <p className="text-2xl font-bold text-green-600">
+            {distribution.total_winners}
+          </p>
+          <p className="text-sm text-gray-600">Winners</p>
+        </div>
+        <div className="text-center p-3 bg-red-50 rounded-lg">
+          <p className="text-2xl font-bold text-red-600">
+            {distribution.total_losers}
+          </p>
+          <p className="text-sm text-gray-600">Losers</p>
+        </div>
+        <div className="text-center p-3 bg-green-50 rounded-lg">
+          <p className="text-xl font-bold text-green-600">
+            {formatCurrency(distribution.avg_winner)}
+          </p>
+          <p className="text-sm text-gray-600">Avg Winner</p>
+        </div>
+        <div className="text-center p-3 bg-red-50 rounded-lg">
+          <p className="text-xl font-bold text-red-600">
+            {formatCurrency(distribution.avg_loser)}
+          </p>
+          <p className="text-sm text-gray-600">Avg Loser</p>
+        </div>
+      </div>
+
+      <div className="h-96">
+        <ResponsiveContainer width="100%" height="100%">
+          {viewType === 'bar' ? (
+            <BarChart data={combinedData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="range"
+                tick={{ fontSize: 12 }}
+                angle={-45}
+                textAnchor="end"
+                height={80}
+              />
+              <YAxis tick={{ fontSize: 12 }} />
+              <Tooltip
+                formatter={(value: any, name: string) => {
+                  const absValue = Math.abs(value as number);
+                  const label = name === 'winners' ? 'Winners' : 'Losers';
+                  return [absValue, label];
+                }}
+              />
+              <Legend />
+              <Bar dataKey="winners" fill="#10b981" name="Winners" radius={[2, 2, 0, 0]} />
+              <Bar dataKey="losers" fill="#ef4444" name="Losers" radius={[0, 0, 2, 2]} />
+            </BarChart>
+          ) : (
+            <PieChart>
+              <Pie
+                data={pieData}
+                cx="50%"
+                cy="50%"
+                labelLine={false}
+                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
+                outerRadius={120}
+                fill="#8884d8"
+                dataKey="value"
+              >
+                {pieData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend />
+            </PieChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default TradeDistribution;
+

--- a/frontend/src/components/analytics/__tests__/AdvancedCharts.test.tsx
+++ b/frontend/src/components/analytics/__tests__/AdvancedCharts.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+import EquityCurve from '../EquityCurve';
+import TradeDistribution from '../TradeDistribution';
+import MonthlyHeatmap from '../MonthlyHeatmap';
+import api from '../../../services/api';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserver;
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    analytics: {
+      getEquityCurve: vi.fn(),
+      getTradeAnalytics: vi.fn(),
+      getMonthlyPerformance: vi.fn(),
+    },
+  },
+}));
+
+const mockEquityCurveData = {
+  equity_curve: [
+    { date: '2024-01-01T00:00:00', equity: 10000, drawdown: 0, trade_id: 1, symbol: 'AAPL', pnl: 100 },
+    { date: '2024-01-02T00:00:00', equity: 10150, drawdown: 0, trade_id: 2, symbol: 'TSLA', pnl: 150 },
+    { date: '2024-01-03T00:00:00', equity: 10100, drawdown: -3.3, trade_id: 3, symbol: 'MSFT', pnl: -50 },
+  ],
+  drawdown_periods: [
+    {
+      start_date: '2024-01-03T00:00:00',
+      end_date: '2024-01-04T00:00:00',
+      max_drawdown: -8.5,
+      duration_days: 1,
+    },
+  ],
+};
+
+const mockTradeDistribution = {
+  trade_distribution: {
+    win_distribution: [
+      { range: '$0 - $50', count: 5, percentage: 25 },
+      { range: '$50 - $100', count: 8, percentage: 40 },
+      { range: '$100 - $200', count: 7, percentage: 35 },
+    ],
+    loss_distribution: [
+      { range: '$-50 - $0', count: 3, percentage: 30 },
+      { range: '$-100 - $-50', count: 4, percentage: 40 },
+      { range: '$-200 - $-100', count: 3, percentage: 30 },
+    ],
+    total_winners: 20,
+    total_losers: 10,
+    avg_winner: 75.5,
+    avg_loser: -65.2,
+  },
+};
+
+const mockMonthlyData = {
+  monthly_returns: [
+    { month: '2024-01', pnl: 1500, trades: 25, win_rate: 68 },
+    { month: '2024-02', pnl: -500, trades: 18, win_rate: 44 },
+    { month: '2024-03', pnl: 2200, trades: 32, win_rate: 72 },
+  ],
+};
+
+describe('Advanced Analytics Charts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('EquityCurve', () => {
+    test('renders equity curve correctly', async () => {
+      (api.analytics.getEquityCurve as any).mockResolvedValue(mockEquityCurveData);
+
+      render(<EquityCurve timeframe="1M" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Equity Curve')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Current Equity')).toBeInTheDocument();
+      expect(screen.getByText('Total Trades')).toBeInTheDocument();
+      expect(screen.getByText('Max Drawdown')).toBeInTheDocument();
+    });
+
+    test('shows drawdown periods warning', async () => {
+      (api.analytics.getEquityCurve as any).mockResolvedValue(mockEquityCurveData);
+
+      render(<EquityCurve timeframe="1M" />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Significant Drawdown Period/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('TradeDistribution', () => {
+    test('renders trade distribution correctly', async () => {
+      (api.analytics.getTradeAnalytics as any).mockResolvedValue(mockTradeDistribution);
+
+      render(<TradeDistribution timeframe="3M" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Trade Distribution')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('20')).toBeInTheDocument();
+      expect(screen.getByText('10')).toBeInTheDocument();
+    });
+
+    test('toggles between bar and pie chart views', async () => {
+      (api.analytics.getTradeAnalytics as any).mockResolvedValue(mockTradeDistribution);
+
+      render(<TradeDistribution timeframe="3M" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Bar Chart')).toBeInTheDocument();
+        expect(screen.getByText('Pie Chart')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('MonthlyHeatmap', () => {
+    test('renders monthly heatmap correctly', async () => {
+      (api.analytics.getMonthlyPerformance as any).mockResolvedValue(mockMonthlyData);
+
+      render(<MonthlyHeatmap />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Monthly Performance Heatmap')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Total P&L')).toBeInTheDocument();
+      expect(screen.getByText('Positive Months')).toBeInTheDocument();
+    });
+  });
+});
+

--- a/frontend/src/components/analytics/__tests__/PortfolioAnalytics.test.tsx
+++ b/frontend/src/components/analytics/__tests__/PortfolioAnalytics.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserver;
 import PortfolioAnalytics from '../PortfolioAnalytics';
 import api from '../../../services/api';
 
@@ -83,7 +89,7 @@ describe('PortfolioAnalytics', () => {
       expect(screen.getByText('1 Week')).toBeInTheDocument();
     });
 
-    const weekButton = screen.getByText('1 Week');
+    const weekButton = screen.getAllByText('1 Week')[0];
     fireEvent.click(weekButton);
 
     await waitFor(() => {

--- a/frontend/src/components/analytics/index.ts
+++ b/frontend/src/components/analytics/index.ts
@@ -1,1 +1,4 @@
 export { default as PortfolioAnalytics } from './PortfolioAnalytics';
+export { default as EquityCurve } from './EquityCurve';
+export { default as TradeDistribution } from './TradeDistribution';
+export { default as MonthlyHeatmap } from './MonthlyHeatmap';


### PR DESCRIPTION
## Summary
- add equity curve component with drawdown view
- implement trade distribution and monthly heatmap charts
- integrate new tabs in portfolio analytics

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68b50d75cb588331b3cdbee24da123e0