### PR TITLE
Handle zero PnL trades in analytics metrics

### DIFF
--- a/app/analytics/portfolio_analytics.py
+++ b/app/analytics/portfolio_analytics.py
@@ -262,7 +262,7 @@ class PortfolioAnalytics:
         peak_equity = 0.0
 
         for trade in trades:
-            if trade.pnl:
+            if trade.pnl is not None:
                 running_pnl += float(trade.pnl)
 
                 if running_pnl > peak_equity:
@@ -337,7 +337,7 @@ class PortfolioAnalytics:
         if not trades:
             return {"bins": [], "win_distribution": [], "loss_distribution": []}
 
-        pnl_values = [float(t.pnl) for t in trades if t.pnl]
+        pnl_values = [float(t.pnl) for t in trades if t.pnl is not None]
         if not pnl_values:
             return {"bins": [], "win_distribution": [], "loss_distribution": []}
 
@@ -395,9 +395,9 @@ class PortfolioAnalytics:
 
                 holding_times.append(hours)
 
-                if trade.pnl and trade.pnl > 0:
+                if trade.pnl is not None and trade.pnl > 0:
                     winning_times.append(hours)
-                elif trade.pnl and trade.pnl < 0:
+                elif trade.pnl is not None and trade.pnl < 0:
                     losing_times.append(hours)
 
         if not holding_times:
@@ -435,7 +435,7 @@ class PortfolioAnalytics:
         monthly_data = {}
 
         for trade in trades:
-            if trade.pnl and trade.opened_at:
+            if trade.pnl is not None and trade.opened_at:
                 month_key = trade.opened_at.strftime("%Y-%m")
 
                 if month_key not in monthly_data:
@@ -509,7 +509,7 @@ class PortfolioAnalytics:
         if not trades:
             return {}
 
-        pnl_values = [float(t.pnl) for t in trades if t.pnl]
+        pnl_values = [float(t.pnl) for t in trades if t.pnl is not None]
         if len(pnl_values) < 2:
             return {}
 
@@ -583,7 +583,7 @@ class PortfolioAnalytics:
         if not trades:
             return {"error": "No trades available for risk analysis"}
 
-        pnl_values = [float(t.pnl) for t in trades if t.pnl]
+        pnl_values = [float(t.pnl) for t in trades if t.pnl is not None]
         if len(pnl_values) < 2:
             return {"error": "Insufficient data for risk analysis"}
 
@@ -596,7 +596,7 @@ class PortfolioAnalytics:
         equity_curve = []
         running_pnl = 0
         for trade in sorted(trades, key=lambda x: x.opened_at):
-            if trade.pnl:
+            if trade.pnl is not None:
                 running_pnl += float(trade.pnl)
                 equity_curve.append(running_pnl)
 
@@ -707,7 +707,7 @@ class PortfolioAnalytics:
         if len(trades) < 10:
             return {"error": "Insufficient data for VaR analysis"}
 
-        pnl_values = [float(t.pnl) for t in trades if t.pnl]
+        pnl_values = [float(t.pnl) for t in trades if t.pnl is not None]
         pnl_sorted = sorted(pnl_values)
 
         var_levels = [0.01, 0.05, 0.10, 0.25]
@@ -834,7 +834,7 @@ class PortfolioAnalytics:
 
             symbol_stats[symbol]["trades"] += 1
 
-            if trade.pnl:
+            if trade.pnl is not None:
                 pnl = float(trade.pnl)
                 symbol_stats[symbol]["total_pnl"] += pnl
                 symbol_stats[symbol]["pnl_values"].append(pnl)
@@ -954,7 +954,7 @@ class PortfolioAnalytics:
         if len(trades) < 2:
             return {"error": "Insufficient data for risk-adjusted returns"}
 
-        pnl_values = [float(t.pnl) for t in trades if t.pnl]
+        pnl_values = [float(t.pnl) for t in trades if t.pnl is not None]
         if len(pnl_values) < 2:
             return {"error": "Insufficient P&L data"}
 
@@ -1076,7 +1076,7 @@ class PortfolioAnalytics:
             )
         ).all()
 
-        daily_pnl = sum(float(t.pnl) for t in recent_trades if t.pnl)
+        daily_pnl = sum(float(t.pnl) for t in recent_trades if t.pnl is not None)
 
         return {
             "configured_limits": {

--- a/tests/analytics/test_zero_pnl.py
+++ b/tests/analytics/test_zero_pnl.py
@@ -1,0 +1,126 @@
+import pytest
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.user import User
+from app.models.portfolio import Portfolio
+from app.models.trades import Trade
+from app.analytics.portfolio_analytics import PortfolioAnalytics
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def test_user(db_session):
+    user = User(email="zero@example.com", username="zerouser", password_hash="test", is_verified=True)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_portfolio(db_session, test_user):
+    portfolio = Portfolio(
+        name="zero_portfolio",
+        api_key_encrypted="key",
+        secret_key_encrypted="secret",
+        base_url="http://example.com",
+        broker="alpaca",
+        is_active=True,
+        user_id=test_user.id,
+    )
+    db_session.add(portfolio)
+    db_session.commit()
+    db_session.refresh(portfolio)
+    return portfolio
+
+
+def test_monthly_returns_includes_zero_pnl(db_session, test_user, test_portfolio):
+    analytics = PortfolioAnalytics(db_session)
+    trade = Trade(
+        user_id=test_user.id,
+        portfolio_id=test_portfolio.id,
+        symbol="AAPL",
+        pnl=0.0,
+        quantity=1,
+        entry_price=100.0,
+        status="closed",
+        opened_at=datetime(2024, 1, 15),
+    )
+    db_session.add(trade)
+    db_session.commit()
+
+    query = db_session.query(Trade).filter(Trade.user_id == test_user.id)
+    monthly_returns = analytics._get_monthly_returns(query)
+
+    assert len(monthly_returns) == 1
+    assert monthly_returns[0]["trades"] == 1
+    assert monthly_returns[0]["pnl"] == 0.0
+
+
+def test_risk_metrics_with_zero_pnl(db_session, test_user, test_portfolio):
+    analytics = PortfolioAnalytics(db_session)
+    trade1 = Trade(
+        user_id=test_user.id,
+        portfolio_id=test_portfolio.id,
+        symbol="AAPL",
+        pnl=0.0,
+        quantity=1,
+        entry_price=100.0,
+        status="closed",
+        opened_at=datetime.utcnow(),
+    )
+    trade2 = Trade(
+        user_id=test_user.id,
+        portfolio_id=test_portfolio.id,
+        symbol="AAPL",
+        pnl=50.0,
+        quantity=1,
+        entry_price=100.0,
+        status="closed",
+        opened_at=datetime.utcnow(),
+    )
+    db_session.add_all([trade1, trade2])
+    db_session.commit()
+
+    query = db_session.query(Trade).filter(Trade.user_id == test_user.id)
+    risk_metrics = analytics._get_risk_metrics(query)
+
+    assert risk_metrics
+    assert "volatility" in risk_metrics
+
+
+def test_risk_adjusted_returns_with_zero_pnl(db_session, test_user, test_portfolio):
+    analytics = PortfolioAnalytics(db_session)
+    for pnl in [0.0, 0.0]:
+        trade = Trade(
+            user_id=test_user.id,
+            portfolio_id=test_portfolio.id,
+            symbol="AAPL",
+            pnl=pnl,
+            quantity=1,
+            entry_price=100.0,
+            status="closed",
+            opened_at=datetime.utcnow(),
+        )
+        db_session.add(trade)
+    db_session.commit()
+
+    query = db_session.query(Trade).filter(Trade.user_id == test_user.id)
+    result = analytics._calculate_risk_adjusted_returns(query)
+
+    assert "error" not in result
+    assert "sharpe_ratio" in result


### PR DESCRIPTION
## Summary
- Include trades with zero profit/loss in monthly returns, risk metrics, and risk-adjusted return calculations
- Ensure analytics helpers handle `pnl=0` consistently across equity curve, symbol exposure, and risk limit summaries
- Add tests covering zero PnL trades

## Testing
- `pytest tests/analytics/test_zero_pnl.py -q`
- `pytest tests/analytics -q`
- `pytest -q` *(fails: No module named 'app.execution.bracket_order_integration_test', 'order_processor', 'app.execution.scheduler', 'app.execution.trailing_stop_monitor')*


------
https://chatgpt.com/codex/tasks/task_e_68b5c1ede4b08331896eb621b20d3c02