### PR TITLE
Use returns for portfolio analytics

### DIFF
--- a/tests/analytics/test_advanced_analytics.py
+++ b/tests/analytics/test_advanced_analytics.py
@@ -90,16 +90,16 @@ def test_trade_distribution_analysis(db_session, test_user, test_portfolio):
     """Test análisis de distribución de trades"""
     analytics = PortfolioAnalytics(db_session)
 
-    pnl_values = [100, 150, 75, 200, -50, -25, -100, -75, 300, -150]
+    returns = [1.0, 1.5, 0.75, 2.0, -0.5, -0.25, -1.0, -0.75, 3.0, -1.5]
 
-    for pnl in pnl_values:
+    for r in returns:
         trade = Trade(
             user_id=test_user.id,
             portfolio_id=test_portfolio.id,
             symbol="AAPL",
             quantity=1,
             entry_price=100.0,
-            pnl=pnl,
+            pnl=r * 100.0,
             status="filled",
         )
         db_session.add(trade)

--- a/tests/analytics/test_metrics_calculations.py
+++ b/tests/analytics/test_metrics_calculations.py
@@ -132,7 +132,7 @@ def test_sharpe_ratio_calculation(db_session, test_user, test_portfolio):
     returns = [p / 100.0 for p in pnls]
     avg_return = statistics.mean(returns)
     std_return = statistics.stdev(returns)
-    risk_free_rate = 0.0055 / 252
+    risk_free_rate = 0.02 / 252
     expected_sharpe = round((avg_return - risk_free_rate) / std_return, 4)
 
     assert sharpe == expected_sharpe

--- a/tests/analytics/test_risk_dashboard.py
+++ b/tests/analytics/test_risk_dashboard.py
@@ -84,14 +84,14 @@ def test_get_risk_dashboard_data(db_session, test_user, test_portfolio):
 def test_advanced_risk_metrics_calculation(db_session, test_user, test_portfolio):
   analytics = PortfolioAnalytics(db_session)
 
-  pnl_values = [100, -50, 75, -25, 150, -75, 200, -100, 80, -40]
+  returns = [0.1, -0.05, 0.075, -0.025, 0.15, -0.075, 0.2, -0.1, 0.08, -0.04]
 
-  for i, pnl in enumerate(pnl_values):
+  for i, r in enumerate(returns):
       trade = Trade(
           user_id=test_user.id,
           portfolio_id=test_portfolio.id,
           symbol="TEST",
-          pnl=pnl,
+          pnl=r * 1000,
           quantity=10,
           entry_price=100.0,
           status="filled",
@@ -104,7 +104,7 @@ def test_advanced_risk_metrics_calculation(db_session, test_user, test_portfolio
   base_query = db_session.query(Trade).filter(Trade.user_id == test_user.id)
   risk_metrics = analytics._get_advanced_risk_metrics(base_query)
 
-  assert risk_metrics["total_return"] == sum(pnl_values)
+  assert risk_metrics["total_return"] == sum(returns)
   assert risk_metrics["volatility"] > 0
   assert "sharpe_ratio" in risk_metrics
   assert "var_95" in risk_metrics


### PR DESCRIPTION
## Summary
- compute per-trade returns and replace `pnl_values` with normalized returns across analytics
- switch to daily risk-free rate and update VaR and distribution interpretations to percentages
- adjust unit tests for return-based metrics

## Testing
- `pytest tests/analytics -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.execution.bracket_order_integration_test')*


------
https://chatgpt.com/codex/tasks/task_e_68b5c60c0cac8331a6e676cbe5cf2355