### PR TITLE
Add Strategy model and schemas with relationships

### DIFF
--- a/app/models/signal.py
+++ b/app/models/signal.py
@@ -1,7 +1,7 @@
 # backend/app/models/signal.py
 
 from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, Text, ForeignKey
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, foreign
 from app.database import Base
 from app.utils.time import now_eastern
 
@@ -38,6 +38,13 @@ class Signal(Base):
 
     # En la clase Signal, añadir esta relación
     orders = relationship("Order", back_populates="signal")
+
+    # Strategy relation
+    strategy = relationship(
+        "Strategy",
+        back_populates="signals",
+        primaryjoin="foreign(Signal.strategy_id)==Strategy.name",
+    )
 
     def __repr__(self):
         return f"<Signal({self.strategy_id}:{self.symbol}, {self.action}, {self.status}, user:{self.user_id})>"

--- a/app/models/strategy.py
+++ b/app/models/strategy.py
@@ -1,19 +1,50 @@
-from sqlalchemy import Column, Integer, String, DateTime
-from app.utils.time import now_eastern
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship, foreign
 
 from app.database import Base
+from app.utils.time import now_eastern
 
 
 class Strategy(Base):
     __tablename__ = "strategies"
 
     id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, index=True, unique=True)
+    description = Column(Text, nullable=True)
 
-    name = Column(String(100), unique=True, nullable=False, index=True)
-    description = Column(String(255), nullable=True)
+    # Configuración de reglas
+    entry_rules = Column(JSON, nullable=False)  # {"indicators": [], "conditions": []}
+    exit_rules = Column(JSON, nullable=False)  # {"stop_loss": 0.02, "take_profit": 0.04}
+    risk_parameters = Column(JSON, nullable=False)  # {"max_position_size": 0.05}
+    position_sizing = Column(JSON, nullable=False)  # {"type": "fixed", "amount": 1000}
+
+    # Estado y configuración
+    is_active = Column(Boolean, default=True)
     created_at = Column(DateTime(timezone=True), default=now_eastern)
     updated_at = Column(DateTime(timezone=True), default=now_eastern, onupdate=now_eastern)
 
-    def __repr__(self):
-        return f"<Strategy({self.id}, {self.name})>"
+    # Relaciones
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    user = relationship("User", back_populates="strategies")
+
+    # Relación con señales y trades
+    signals = relationship(
+        "Signal",
+        back_populates="strategy",
+        cascade="all, delete-orphan",
+        primaryjoin="Strategy.name==foreign(Signal.strategy_id)",
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - representación simple
+        return f"<Strategy({self.name}, user:{self.user_id}, active:{self.is_active})>"
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -20,6 +20,7 @@ class User(Base):
     trades = relationship("Trade", back_populates="user")
     portfolios = relationship("Portfolio", back_populates="user")
     risk_limits = relationship("RiskLimit", back_populates="user")
+    strategies = relationship("Strategy", back_populates="user")
 
     # Per-user limit for simultaneous positions
     position_limit = Column(Integer, default=7)

--- a/app/schemas/strategy.py
+++ b/app/schemas/strategy.py
@@ -1,11 +1,42 @@
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, validator
+
+
+class EntryRules(BaseModel):
+    indicators: List[str] = []
+    conditions: List[Dict[str, Any]] = []
+    timeframe: str = "1h"
+
+
+class ExitRules(BaseModel):
+    stop_loss: Optional[float] = None
+    take_profit: Optional[float] = None
+    trailing_stop: Optional[float] = None
+    max_hold_time: Optional[int] = None  # en horas
+
+
+class RiskParameters(BaseModel):
+    max_position_size: float = 0.05  # 5% del capital
+    max_daily_loss: Optional[float] = None
+    max_correlation: Optional[float] = 0.7
+
+
+class PositionSizing(BaseModel):
+    type: str = "fixed"  # fixed, percentage, kelly, etc
+    amount: Optional[float] = None
+    percentage: Optional[float] = None
 
 
 class StrategyBase(BaseModel):
     name: str
     description: Optional[str] = None
+    entry_rules: EntryRules
+    exit_rules: ExitRules
+    risk_parameters: RiskParameters
+    position_sizing: PositionSizing
+    is_active: bool = True
 
 
 class StrategyCreate(StrategyBase):
@@ -15,12 +46,19 @@ class StrategyCreate(StrategyBase):
 class StrategyUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+    entry_rules: Optional[EntryRules] = None
+    exit_rules: Optional[ExitRules] = None
+    risk_parameters: Optional[RiskParameters] = None
+    position_sizing: Optional[PositionSizing] = None
+    is_active: Optional[bool] = None
 
 
 class StrategyOut(StrategyBase):
     id: int
+    user_id: int
     created_at: datetime
     updated_at: datetime
 
     class Config:
         from_attributes = True
+


### PR DESCRIPTION
## Summary
- add comprehensive Strategy SQLAlchemy model with rule configuration and user linkage
- expose strategies on User and Signal models
- introduce Pydantic schemas for Strategy validation

## Testing
- `pytest` *(fails: ModuleNotFoundError for app.execution.* and order_processor)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ca1db490833198638efb5bf1ddd0