### PR TITLE
Add strategy performance, position management, and reporting endpoints

### DIFF
--- a/app/api/v1/positions.py
+++ b/app/api/v1/positions.py
@@ -1,0 +1,127 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from typing import Dict, Any, Optional
+
+from app.database import get_db
+from app.models.user import User
+from app.core.auth import get_current_verified_user
+from app.services.advanced_position_manager import AdvancedPositionManager
+import logging
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/positions/current", response_model=Dict[str, Any])
+async def get_current_positions(
+    portfolio_id: Optional[int] = Query(None, description="Portfolio ID (optional, uses active if not provided)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Obtener todas las posiciones abiertas actuales"""
+    try:
+        position_manager = AdvancedPositionManager(db)
+        positions = position_manager.track_open_positions(current_user.id, portfolio_id)
+
+        if "error" in positions:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=positions["error"],
+            )
+
+        return positions
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting current positions: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve current positions",
+        )
+
+
+@router.get("/positions/exposure", response_model=Dict[str, Any])
+async def get_exposure_analysis(
+    portfolio_id: Optional[int] = Query(None, description="Portfolio ID (optional)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Análisis completo de exposición por símbolo, sector y estrategia"""
+    try:
+        position_manager = AdvancedPositionManager(db)
+        exposure = position_manager.calculate_exposure(current_user.id, portfolio_id)
+
+        if "error" in exposure:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=exposure["error"],
+            )
+
+        return exposure
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error calculating exposure: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to calculate exposure",
+        )
+
+
+@router.get("/positions/history", response_model=Dict[str, Any])
+async def get_position_history(
+    days: int = Query(30, ge=1, le=365, description="Number of days to look back"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Historial de posiciones en los últimos N días"""
+    try:
+        position_manager = AdvancedPositionManager(db)
+        history = position_manager.get_position_history(current_user.id, days)
+
+        if "error" in history:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=history["error"],
+            )
+
+        return history
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting position history: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve position history",
+        )
+
+
+@router.get("/positions/sizing-analysis", response_model=Dict[str, Any])
+async def get_position_sizing_analysis(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Análisis de patrones de position sizing"""
+    try:
+        position_manager = AdvancedPositionManager(db)
+        analysis = position_manager.analyze_position_sizing(current_user.id)
+
+        if "error" in analysis:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=analysis["error"],
+            )
+
+        return analysis
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error analyzing position sizing: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to analyze position sizing",
+        )

--- a/app/api/v1/reports.py
+++ b/app/api/v1/reports.py
@@ -1,0 +1,184 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from typing import Optional, Dict, Any
+from datetime import datetime, date
+
+from app.database import get_db
+from app.models.user import User
+from app.core.auth import get_current_verified_user
+from app.services.trade_reporting import TradeReporting
+from app.schemas.reporting import (
+    DailyReportResponse,
+    WeeklyReportResponse,
+    StrategyComparisonResponse,
+    PortfolioHealthResponse,
+)
+import logging
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/reports/daily", response_model=DailyReportResponse)
+async def get_daily_report(
+    report_date: Optional[date] = Query(None, description="Date for report (YYYY-MM-DD), defaults to today"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Generar reporte diario de trading"""
+    try:
+        reporting = TradeReporting(db)
+        target_date = None
+
+        if report_date:
+            target_date = datetime.combine(report_date, datetime.min.time())
+
+        report = reporting.generate_daily_report(current_user.id, target_date)
+
+        if "error" in report:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=report["error"],
+            )
+
+        return report
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating daily report: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate daily report",
+        )
+
+
+@router.get("/reports/weekly", response_model=WeeklyReportResponse)
+async def get_weekly_report(
+    weeks_back: int = Query(0, ge=0, le=52, description="Number of weeks back (0 = current week)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Generar reporte semanal de trading"""
+    try:
+        reporting = TradeReporting(db)
+        report = reporting.generate_weekly_report(current_user.id, weeks_back)
+
+        if "error" in report:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=report["error"],
+            )
+
+        return report
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating weekly report: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate weekly report",
+        )
+
+
+@router.get("/reports/strategy-comparison", response_model=StrategyComparisonResponse)
+async def get_strategy_comparison_report(
+    days: int = Query(30, ge=1, le=365, description="Period in days for comparison"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Reporte comparativo de todas las estrategias"""
+    try:
+        reporting = TradeReporting(db)
+        report = reporting.generate_strategy_comparison_report(current_user.id, days)
+
+        if "error" in report:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=report["error"],
+            )
+
+        return report
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating strategy comparison: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate strategy comparison",
+        )
+
+
+@router.get("/reports/portfolio-health", response_model=PortfolioHealthResponse)
+async def get_portfolio_health_report(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Reporte completo de salud del portfolio"""
+    try:
+        reporting = TradeReporting(db)
+        report = reporting.generate_portfolio_health_report(current_user.id)
+
+        if "error" in report:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=report["error"],
+            )
+
+        return report
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating portfolio health report: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate portfolio health report",
+        )
+
+
+@router.get("/reports/summary", response_model=Dict[str, Any])
+async def get_reports_summary(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_verified_user),
+):
+    """Resumen rápido de todos los reportes para dashboard"""
+    try:
+        reporting = TradeReporting(db)
+
+        # Generar múltiples reportes en paralelo (simplificado)
+        daily = reporting.generate_daily_report(current_user.id)
+        weekly = reporting.generate_weekly_report(current_user.id, 0)
+        health = reporting.generate_portfolio_health_report(current_user.id)
+
+        # Extraer métricas clave
+        summary = {
+            "today": {
+                "pnl": daily.get("summary", {}).get("daily_pnl", 0),
+                "trades": daily.get("summary", {}).get("trades_closed", 0),
+                "win_rate": daily.get("win_rate", 0),
+            },
+            "this_week": {
+                "pnl": weekly.get("summary", {}).get("weekly_pnl", 0),
+                "trades": weekly.get("summary", {}).get("total_trades", 0),
+                "consistency": weekly.get("summary", {}).get("consistency_score", 0),
+            },
+            "portfolio_health": {
+                "risk_level": health.get("portfolio_health", {}).get("risk_level", "Unknown"),
+                "risk_score": health.get("portfolio_health", {}).get("risk_score", 0),
+                "open_positions": health.get("current_positions", {}).get("total_positions", 0),
+                "total_exposure": health.get("exposure_analysis", {}).get("total_exposure_pct", 0),
+            },
+            "generated_at": datetime.now().isoformat(),
+        }
+
+        return summary
+
+    except Exception as e:
+        logger.error(f"Error generating reports summary: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate reports summary",
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from app.api.v1.exit_rules import router as exit_rules_router
 from app.api.v1.bracket_orders import router as bracket_orders_router
 from app.api.v1.analytics import router as analytics_router
 from app.api.ws import router as ws_router
-from app.api.v1 import auth, trades, strategies, portfolio, risk, system
+from app.api.v1 import auth, trades, strategies, portfolio, risk, system, positions, reports
 from app.database import SessionLocal
 from app.services import portfolio_service
 from app.integrations import refresh_broker_client
@@ -42,6 +42,8 @@ app.include_router(system.router, prefix="/api/v1/system", tags=["system"])
 app.include_router(exit_rules_router, prefix="/api/v1/exit-rules", tags=["Exit Rules"])
 app.include_router(bracket_orders_router, prefix="/api/v1/bracket-orders", tags=["Bracket Orders"])
 app.include_router(analytics_router, prefix="/api/v1/analytics", tags=["analytics"])
+app.include_router(positions.router, prefix="/api/v1", tags=["positions"])
+app.include_router(reports.router, prefix="/api/v1", tags=["reports"])
 app.include_router(ws_router)
 
 


### PR DESCRIPTION
## Summary
- add performance, equity curve, and multi-strategy comparison endpoints
- introduce position tracking, exposure analysis, history, and sizing routes
- provide daily, weekly, comparison, portfolio health, and summary report APIs and register routers

## Testing
- `alembic revision --autogenerate -m "Add advanced strategy and position management"` (fails: connection refused)
- `alembic upgrade head` (fails: connection refused)
- `pytest` (fails: Pydantic `regex` removed errors)

------
https://chatgpt.com/codex/tasks/task_e_68b5d3da45a88331a97786c2ab65cb59