### PR TITLE
fix: resolve frontend build errors

### DIFF
--- a/frontend/src/components/ExitRulesManager.tsx
+++ b/frontend/src/components/ExitRulesManager.tsx
@@ -29,7 +29,7 @@ const ExitRulesManager: React.FC = () => {
   const [calculatorPrice, setCalculatorPrice] = useState<string>('100');
   const [calculationResult, setCalculationResult] = useState<PriceCalculation | null>(null);
 
-  const API_BASE = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+  const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
   useEffect(() => {
     loadAllExitRules();

--- a/frontend/src/components/analytics/RiskDashboard.tsx
+++ b/frontend/src/components/analytics/RiskDashboard.tsx
@@ -4,7 +4,6 @@ import {
   AlertTriangle,
   TrendingDown,
   Clock,
-  Target,
   BarChart3,
   Gauge,
   Users,
@@ -417,7 +416,7 @@ const RiskDashboard: React.FC<RiskDashboardProps> = ({ timeframe = '3M', portfol
                 {data.risk_limits_status.configured_limits && Object.entries(data.risk_limits_status.configured_limits).map(([key, value]) => (
                   <div key={key} className="flex justify-between text-sm">
                     <span className="text-gray-600 capitalize">{key.replace(/_/g, ' ').replace(/max /g, 'Max ').replace(/trading/g, 'Trading')}:</span>
-                    <span className="font-medium text-gray-900">{typeof value === 'number' ? (key.includes('drawdown') ? `${value}%` : formatCurrency(value)) : value}</span>
+                    <span className="font-medium text-gray-900">{typeof value === 'number' ? (key.includes('drawdown') ? `${value}%` : formatCurrency(value)) : String(value)}</span>
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/analytics/TradeDistribution.tsx
+++ b/frontend/src/components/analytics/TradeDistribution.tsx
@@ -228,12 +228,12 @@ const TradeDistribution: React.FC<TradeDistributionProps> = ({
                 cx="50%"
                 cy="50%"
                 labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
+                label={({ name, percent = 0 }) => `${name}: ${(percent * 100).toFixed(0)}%`}
                 outerRadius={120}
                 fill="#8884d8"
                 dataKey="value"
               >
-                {pieData.map((entry, index) => (
+                {pieData.map((_, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
               </Pie>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -23,5 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
- fix ExitRulesManager API base retrieval to use Vite env vars
- clean up analytics components to satisfy TypeScript
- exclude tests from frontend tsconfig to prevent build failures

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any errors)*
- `pytest` *(fails: PydanticUserError: regex is removed; use pattern instead)*

------
https://chatgpt.com/codex/tasks/task_e_68b611c8ebac83319e345df095f71f3c