### PR TITLE
fix: use pattern for report type validation

### DIFF
--- a/app/schemas/reporting.py
+++ b/app/schemas/reporting.py
@@ -43,7 +43,9 @@ class PortfolioHealthResponse(BaseModel):
 
 
 class ReportRequest(BaseModel):
-    report_type: str = Field(..., regex="^(daily|weekly|strategy_comparison|portfolio_health)$")
+    report_type: str = Field(
+        ..., pattern="^(daily|weekly|strategy_comparison|portfolio_health)$"
+    )
     date: Optional[date] = None
     weeks_back: Optional[int] = Field(default=0, ge=0)
     days_period: Optional[int] = Field(default=30, ge=1, le=365)


### PR DESCRIPTION
## Summary
- replace deprecated `regex` Field argument with `pattern`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.execution.bracket_order_integration_test'; tests/test_order_concurrency.py etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b61373ebb083318e0f41fe38bede85