### PR TITLE
Fix circular import in execution package

### DIFF
--- a/app/execution/__init__.py
+++ b/app/execution/__init__.py
@@ -3,7 +3,6 @@ from .broker_executor import BrokerExecutor
 from .order_processor import OrderProcessor
 from .scheduler import ExecutionScheduler, execution_scheduler
 from .background_tasks import BackgroundTaskManager, background_task_manager
-from .testing import ExecutionTester
 
 __all__ = [
     "OrderManager",
@@ -13,5 +12,4 @@ __all__ = [
     "execution_scheduler",
     "BackgroundTaskManager",
     "background_task_manager",
-    "ExecutionTester",
 ]


### PR DESCRIPTION
## Summary
- avoid circular import when loading `WebhookProcessor` by removing `ExecutionTester` from `app.execution.__init__`

## Testing
- `pytest` *(fails: ModuleNotFoundError for app.execution.bracket_order_integration_test, tests/test_order_concurrency.py, tests/test_scheduler_connection_pool.py, tests/test_trailing_stop_monitor.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b613ed1b008331b9caf71906efe1d9