### PR TITLE
Modernize dashboard with advanced metrics and charts

### DIFF
--- a/frontend/src/components/dashboard/MetricCard.tsx
+++ b/frontend/src/components/dashboard/MetricCard.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { LucideIcon } from 'lucide-react';
+
+interface MetricCardProps {
+  title: string;
+  value: string;
+  change?: {
+    value: string;
+    type: 'positive' | 'negative' | 'neutral';
+    period: string;
+  };
+  icon: LucideIcon;
+  trend?: number[];
+  loading?: boolean;
+  format?: 'currency' | 'percentage' | 'number';
+}
+
+const MetricCard: React.FC<MetricCardProps> = ({
+  title,
+  value,
+  change,
+  icon: Icon,
+  trend,
+  loading = false
+}) => {
+  const getChangeColor = (type: 'positive' | 'negative' | 'neutral') => {
+    switch (type) {
+      case 'positive':
+        return 'text-success-600 bg-success-50 border-success-200';
+      case 'negative':
+        return 'text-error-600 bg-error-50 border-error-200';
+      case 'neutral':
+        return 'text-slate-600 bg-slate-50 border-slate-200';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="card p-6 animate-pulse">
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-4 bg-slate-200 rounded w-24"></div>
+          <div className="h-10 w-10 bg-slate-200 rounded-xl"></div>
+        </div>
+        <div className="h-8 bg-slate-200 rounded w-32 mb-2"></div>
+        <div className="h-4 bg-slate-200 rounded w-20"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card p-6 hover:shadow-medium transition-all duration-300 group">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-slate-600 group-hover:text-slate-900 transition-colors">
+          {title}
+        </h3>
+        <div className="p-3 rounded-xl bg-primary-50 text-primary-600 group-hover:bg-primary-100 transition-colors">
+          <Icon className="h-5 w-5" />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-2xl font-bold text-slate-900">
+          {value}
+        </p>
+
+        {change && (
+          <div className="flex items-center space-x-2">
+            <span className={`inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-semibold border ${getChangeColor(change.type)}`}>
+              {change.value}
+            </span>
+            <span className="text-xs text-slate-500">{change.period}</span>
+          </div>
+        )}
+
+        {trend && trend.length > 0 && (
+          <div className="mt-4">
+            <div className="flex items-end space-x-1 h-8">
+              {trend.map((value, index) => (
+                <div
+                  key={index}
+                  className="bg-primary-200 rounded-sm flex-1 transition-all duration-300 hover:bg-primary-300"
+                  style={{ height: `${Math.max(4, (value / Math.max(...trend)) * 100)}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricCard;
+

--- a/frontend/src/components/dashboard/PortfolioChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioChart.tsx
@@ -1,0 +1,211 @@
+import React, { useState } from 'react';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+
+interface ChartDataPoint {
+  date: string;
+  value: number;
+  pnl?: number;
+}
+
+interface PortfolioChartProps {
+  data: ChartDataPoint[];
+  loading?: boolean;
+  timeframe?: '1D' | '1W' | '1M' | '3M' | '1Y';
+  onTimeframeChange?: (timeframe: '1D' | '1W' | '1M' | '3M' | '1Y') => void;
+}
+
+const PortfolioChart: React.FC<PortfolioChartProps> = ({
+  data,
+  loading = false,
+  timeframe = '1D',
+  onTimeframeChange
+}) => {
+  const [selectedPeriod, setSelectedPeriod] = useState(timeframe);
+
+  const timeframes = [
+    { key: '1D', label: '1D' },
+    { key: '1W', label: '1W' },
+    { key: '1M', label: '1M' },
+    { key: '3M', label: '3M' },
+    { key: '1Y', label: '1Y' },
+  ] as const;
+
+  const currentValue = data.length > 0 ? data[data.length - 1].value : 0;
+  const previousValue = data.length > 1 ? data[0].value : currentValue;
+  const change = currentValue - previousValue;
+  const changePercent = previousValue !== 0 ? ((change / previousValue) * 100) : 0;
+  const isPositive = change >= 0;
+
+  // Generate SVG path for the chart
+  const generatePath = () => {
+    if (data.length === 0) return '';
+    
+    const width = 400;
+    const height = 120;
+    const padding = 20;
+    
+    const minValue = Math.min(...data.map(d => d.value));
+    const maxValue = Math.max(...data.map(d => d.value));
+    const valueRange = maxValue - minValue || 1;
+    
+    const points = data.map((point, index) => {
+      const x = padding + ((width - 2 * padding) * index) / (data.length - 1);
+      const y = height - padding - ((point.value - minValue) / valueRange) * (height - 2 * padding);
+      return `${x},${y}`;
+    });
+    
+    return `M ${points.join(' L ')}`;
+  };
+
+  const generateGradientPath = () => {
+    const path = generatePath();
+    if (!path) return '';
+    
+    const width = 400;
+    const height = 120;
+    return `${path} L ${width - 20},${height - 20} L 20,${height - 20} Z`;
+  };
+
+  if (loading) {
+    return (
+      <div className="card p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="space-y-2">
+            <div className="h-4 bg-slate-200 rounded w-32 animate-pulse"></div>
+            <div className="h-8 bg-slate-200 rounded w-48 animate-pulse"></div>
+          </div>
+          <div className="h-10 bg-slate-200 rounded w-32 animate-pulse"></div>
+        </div>
+        <div className="h-32 bg-slate-200 rounded animate-pulse"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900 mb-1">
+            Portfolio Performance
+          </h3>
+          <div className="flex items-center space-x-3">
+            <span className="text-2xl font-bold text-slate-900">
+              ${currentValue.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+            </span>
+            <div className={`flex items-center space-x-1 px-2.5 py-1 rounded-lg text-sm font-semibold
+              ${isPositive 
+                ? 'bg-success-50 text-success-700 border border-success-200' 
+                : 'bg-error-50 text-error-700 border border-error-200'
+              }`}>
+              {isPositive ? (
+                <TrendingUp className="h-4 w-4" />
+              ) : (
+                <TrendingDown className="h-4 w-4" />
+              )}
+              <span>
+                {isPositive ? '+' : ''}${change.toFixed(2)} ({changePercent.toFixed(2)}%)
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Timeframe Selector */}
+        <div className="flex items-center space-x-1 bg-slate-100 rounded-xl p-1">
+          {timeframes.map((tf) => (
+            <button
+              key={tf.key}
+              onClick={() => {
+                setSelectedPeriod(tf.key);
+                onTimeframeChange?.(tf.key);
+              }}
+              className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 ${
+                selectedPeriod === tf.key
+                  ? 'bg-white text-primary-700 shadow-soft'
+                  : 'text-slate-600 hover:text-slate-900'
+              }`}
+            >
+              {tf.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Chart */}
+      <div className="relative h-32 w-full">
+        <svg
+          width="100%"
+          height="100%"
+          viewBox="0 0 400 120"
+          className="overflow-visible"
+        >
+          <defs>
+            <linearGradient
+              id="portfolioGradient"
+              x1="0%"
+              y1="0%"
+              x2="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor={isPositive ? '#22c55e' : '#ef4444'}
+                stopOpacity="0.2"
+              />
+              <stop
+                offset="100%"
+                stopColor={isPositive ? '#22c55e' : '#ef4444'}
+                stopOpacity="0"
+              />
+            </linearGradient>
+          </defs>
+          
+          {/* Gradient Fill */}
+          <path
+            d={generateGradientPath()}
+            fill="url(#portfolioGradient)"
+            className="transition-all duration-1000"
+          />
+          
+          {/* Main Line */}
+          <path
+            d={generatePath()}
+            stroke={isPositive ? '#22c55e' : '#ef4444'}
+            strokeWidth="2"
+            fill="none"
+            className="transition-all duration-1000"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          
+          {/* Data Points */}
+          {data.map((point, index) => {
+            const width = 400;
+            const height = 120;
+            const padding = 20;
+            const minValue = Math.min(...data.map(d => d.value));
+            const maxValue = Math.max(...data.map(d => d.value));
+            const valueRange = maxValue - minValue || 1;
+            
+            const x = padding + ((width - 2 * padding) * index) / (data.length - 1);
+            const y = height - padding - ((point.value - minValue) / valueRange) * (height - 2 * padding);
+            
+            return (
+              <circle
+                key={index}
+                cx={x}
+                cy={y}
+                r="3"
+                fill={isPositive ? '#22c55e' : '#ef4444'}
+                className="opacity-0 hover:opacity-100 transition-opacity duration-200"
+              />
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export default PortfolioChart;
+

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {
+  Plus, Zap, BarChart3, Shield
+} from 'lucide-react';
+
+interface QuickActionsProps {
+  onAction: (action: string) => void;
+}
+
+const QuickActions: React.FC<QuickActionsProps> = ({ onAction }) => {
+  const actions = [
+    {
+      id: 'new-strategy',
+      title: 'New Strategy',
+      description: 'Create trading strategy',
+      icon: Plus,
+      color: 'bg-primary-500 hover:bg-primary-600',
+      textColor: 'text-white'
+    },
+    {
+      id: 'view-signals',
+      title: 'View Signals',
+      description: 'Check latest signals',
+      icon: Zap,
+      color: 'bg-warning-100 hover:bg-warning-200',
+      textColor: 'text-warning-700'
+    },
+    {
+      id: 'analytics',
+      title: 'Analytics',
+      description: 'Portfolio insights',
+      icon: BarChart3,
+      color: 'bg-success-100 hover:bg-success-200',
+      textColor: 'text-success-700'
+    },
+    {
+      id: 'risk-check',
+      title: 'Risk Check',
+      description: 'Review risk metrics',
+      icon: Shield,
+      color: 'bg-error-100 hover:bg-error-200',
+      textColor: 'text-error-700'
+    }
+  ];
+
+  return (
+    <div className="card p-6">
+      <h3 className="text-lg font-semibold text-slate-900 mb-4">Quick Actions</h3>
+      <div className="grid grid-cols-2 gap-3">
+        {actions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <button
+              key={action.id}
+              onClick={() => onAction(action.id)}
+              className={`p-4 rounded-xl text-left transition-all duration-200 ${action.color} group`}
+            >
+              <div className="flex items-center justify-between mb-2">
+                <Icon className={`h-5 w-5 ${action.textColor}`} />
+              </div>
+              <h4 className={`font-medium text-sm ${action.textColor} mb-1`}>
+                {action.title}
+              </h4>
+              <p className={`text-xs ${action.textColor} opacity-75`}>
+                {action.description}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default QuickActions;
+

--- a/frontend/src/components/dashboard/RecentActivity.tsx
+++ b/frontend/src/components/dashboard/RecentActivity.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import {
+  Clock, CheckCircle, XCircle,
+  AlertTriangle, ArrowUpRight, ArrowDownRight
+} from 'lucide-react';
+import SymbolLogo from '../SymbolLogo';
+
+interface ActivityItem {
+  id: string;
+  type: 'trade' | 'signal' | 'order' | 'alert';
+  symbol: string;
+  action: 'BUY' | 'SELL';
+  status: 'success' | 'pending' | 'error' | 'warning';
+  amount?: number;
+  price?: number;
+  quantity?: number;
+  timestamp: string;
+  description: string;
+}
+
+interface RecentActivityProps {
+  activities: ActivityItem[];
+  loading?: boolean;
+}
+
+const RecentActivity: React.FC<RecentActivityProps> = ({
+  activities,
+  loading = false
+}) => {
+  const getStatusIcon = (status: ActivityItem['status']) => {
+    switch (status) {
+      case 'success':
+        return <CheckCircle className="h-4 w-4 text-success-600" />;
+      case 'pending':
+        return <Clock className="h-4 w-4 text-warning-600" />;
+      case 'error':
+        return <XCircle className="h-4 w-4 text-error-600" />;
+      case 'warning':
+        return <AlertTriangle className="h-4 w-4 text-warning-600" />;
+    }
+  };
+
+  const getStatusBg = (status: ActivityItem['status']) => {
+    switch (status) {
+      case 'success':
+        return 'bg-success-50 border-success-200';
+      case 'pending':
+        return 'bg-warning-50 border-warning-200';
+      case 'error':
+        return 'bg-error-50 border-error-200';
+      case 'warning':
+        return 'bg-warning-50 border-warning-200';
+    }
+  };
+
+  const formatTime = (timestamp: string) => {
+    return new Date(timestamp).toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  const formatAmount = (amount: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  };
+
+  if (loading) {
+    return (
+      <div className="card p-6">
+        <h3 className="text-lg font-semibold text-slate-900 mb-4">Recent Activity</h3>
+        <div className="space-y-4">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="flex items-center space-x-4 animate-pulse">
+              <div className="w-10 h-10 bg-slate-200 rounded-xl"></div>
+              <div className="flex-1 space-y-2">
+                <div className="h-4 bg-slate-200 rounded w-3/4"></div>
+                <div className="h-3 bg-slate-200 rounded w-1/2"></div>
+              </div>
+              <div className="h-4 bg-slate-200 rounded w-16"></div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-lg font-semibold text-slate-900">Recent Activity</h3>
+        <button className="text-sm text-primary-600 hover:text-primary-700 font-medium">
+          View All
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {activities.length === 0 ? (
+          <div className="text-center py-8">
+            <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Clock className="h-8 w-8 text-slate-400" />
+            </div>
+            <p className="text-slate-500">No recent activity</p>
+          </div>
+        ) : (
+          activities.map((activity) => (
+            <div
+              key={activity.id}
+              className="flex items-center space-x-4 p-3 rounded-xl hover:bg-slate-50 transition-colors duration-200 group"
+            >
+              {/* Status & Symbol */}
+              <div className="relative">
+                <div className="w-10 h-10 flex items-center justify-center">
+                  <SymbolLogo symbol={activity.symbol} className="w-8 h-8" />
+                </div>
+                <div className={`absolute -bottom-1 -right-1 w-5 h-5 rounded-full border-2 border-white flex items-center justify-center ${getStatusBg(activity.status)}`}>
+                  {getStatusIcon(activity.status)}
+                </div>
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center space-x-2">
+                  <span className="font-medium text-slate-900">{activity.symbol}</span>
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                    activity.action === 'BUY' 
+                      ? 'bg-success-100 text-success-800' 
+                      : 'bg-error-100 text-error-800'
+                  }`}>
+                    {activity.action === 'BUY' ? (
+                      <ArrowUpRight className="h-3 w-3 mr-1" />
+                    ) : (
+                      <ArrowDownRight className="h-3 w-3 mr-1" />
+                    )}
+                    {activity.action}
+                  </span>
+                </div>
+                <p className="text-sm text-slate-600 truncate">{activity.description}</p>
+                {activity.quantity && activity.price && (
+                  <p className="text-xs text-slate-500">
+                    {activity.quantity} shares @ ${activity.price.toFixed(2)}
+                  </p>
+                )}
+              </div>
+
+              {/* Amount & Time */}
+              <div className="text-right">
+                {activity.amount && (
+                  <p className={`font-semibold text-sm ${
+                    activity.action === 'BUY' ? 'text-error-600' : 'text-success-600'
+                  }`}>
+                    {activity.action === 'BUY' ? '-' : '+'}{formatAmount(activity.amount)}
+                  </p>
+                )}
+                <p className="text-xs text-slate-500">{formatTime(activity.timestamp)}</p>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RecentActivity;
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './styles/globals.css'
 import './utils/timezone'
 import App from './App.tsx'
 


### PR DESCRIPTION
## Summary
- add reusable MetricCard, PortfolioChart, RecentActivity and QuickActions components
- redesign dashboard page to showcase metrics, portfolio performance and activity
- include global styles for consistent theming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b61d9c328483318737ce50fd0e3d03