### PR TITLE
feat: enhance risk dashboard components

### DIFF
--- a/frontend/src/components/risk/CorrelationMatrix.tsx
+++ b/frontend/src/components/risk/CorrelationMatrix.tsx
@@ -1,29 +1,91 @@
-import React from 'react';
-import { Grid } from 'lucide-react';
+import React, { useState } from 'react';
+import { TrendingUp, TrendingDown, Grid, BarChart3 } from 'lucide-react';
 
-interface CorrelationMatrixProps {
-  assets: string[];
-  matrix: number[][]; // values between -1 and 1
-  loading?: boolean;
+interface CorrelationData {
+  symbol1: string;
+  symbol2: string;
+  correlation: number;
+  pValue: number;
+  significance: 'high' | 'medium' | 'low';
 }
 
-const getColor = (value: number) => {
-  const intensity = Math.abs(value);
-  const opacity = intensity;
-  if (value > 0) {
-    return `rgba(34,197,94,${opacity})`; // green
-  }
-  return `rgba(239,68,68,${opacity})`; // red
-};
+interface CorrelationMatrixProps {
+  symbols: string[];
+  correlations: CorrelationData[];
+  loading?: boolean;
+  timeframe?: '1W' | '1M' | '3M' | '6M' | '1Y';
+  onTimeframeChange?: (timeframe: '1W' | '1M' | '3M' | '6M' | '1Y') => void;
+}
 
-const CorrelationMatrix: React.FC<CorrelationMatrixProps> = ({ assets, matrix, loading = false }) => {
+const CorrelationMatrix: React.FC<CorrelationMatrixProps> = ({
+  symbols,
+  correlations,
+  loading = false,
+  timeframe = '3M',
+  onTimeframeChange
+}) => {
+  const [hoveredCell, setHoveredCell] = useState<{symbol1: string, symbol2: string} | null>(null);
+  const [selectedCell, setSelectedCell] = useState<{symbol1: string, symbol2: string} | null>(null);
+
+  const getCorrelation = (symbol1: string, symbol2: string) => {
+    if (symbol1 === symbol2) return 1;
+    const correlation = correlations.find(
+      c => (c.symbol1 === symbol1 && c.symbol2 === symbol2) ||
+           (c.symbol1 === symbol2 && c.symbol2 === symbol1)
+    );
+    return correlation ? correlation.correlation : 0;
+  };
+
+  const getCorrelationData = (symbol1: string, symbol2: string) => {
+    return correlations.find(
+      c => (c.symbol1 === symbol1 && c.symbol2 === symbol2) ||
+           (c.symbol1 === symbol2 && c.symbol2 === symbol1)
+    );
+  };
+
+  const getCorrelationColor = (correlation: number) => {
+    const absCorr = Math.abs(correlation);
+    const intensity = Math.floor(absCorr * 10) / 10;
+    if (correlation > 0) {
+      if (intensity < 0.3) return 'bg-red-100 text-red-800';
+      if (intensity < 0.6) return 'bg-red-200 text-red-900';
+      if (intensity < 0.8) return 'bg-red-400 text-white';
+      return 'bg-red-600 text-white';
+    } else if (correlation < 0) {
+      if (intensity < 0.3) return 'bg-blue-100 text-blue-800';
+      if (intensity < 0.6) return 'bg-blue-200 text-blue-900';
+      if (intensity < 0.8) return 'bg-blue-400 text-white';
+      return 'bg-blue-600 text-white';
+    } else {
+      return 'bg-slate-100 text-slate-800';
+    }
+  };
+
+  const getCorrelationLevel = (correlation: number) => {
+    const absCorr = Math.abs(correlation);
+    if (absCorr < 0.3) return 'Low';
+    if (absCorr < 0.7) return 'Medium';
+    return 'High';
+  };
+
+  const timeframes = [
+    { key: '1W', label: '1W' },
+    { key: '1M', label: '1M' },
+    { key: '3M', label: '3M' },
+    { key: '6M', label: '6M' },
+    { key: '1Y', label: '1Y' },
+  ] as const;
+
   if (loading) {
     return (
       <div className="card p-6">
-        <div className="h-6 bg-slate-200 rounded w-48 mb-4 animate-pulse"></div>
-        <div className="space-y-2">
-          {Array.from({ length: assets.length }).map((_, i) => (
-            <div key={i} className="h-6 bg-slate-200 rounded animate-pulse"></div>
+        <div className="flex items-center justify-between mb-6">
+          <div className="h-6 bg-slate-200 rounded w-40 animate-pulse"></div>
+          <div className="h-8 bg-slate-200 rounded w-32 animate-pulse"></div>
+        </div>
+        <div className="grid grid-cols-6 gap-1 animate-pulse">
+          {Array.from({ length: 36 }).map((_, i) => (
+            <div key={i} className="aspect-square bg-slate-200 rounded"></div>
           ))}
         </div>
       </div>
@@ -31,38 +93,247 @@ const CorrelationMatrix: React.FC<CorrelationMatrixProps> = ({ assets, matrix, l
   }
 
   return (
-    <div className="card p-6 overflow-x-auto">
-      <h3 className="text-lg font-semibold text-slate-900 mb-4 flex items-center">
-        <Grid className="w-5 h-5 mr-2 text-primary-600" />
-        Correlation Matrix
-      </h3>
-      <table className="min-w-full text-xs text-center">
-        <thead>
-          <tr>
-            <th className="p-2"></th>
-            {assets.map(asset => (
-              <th key={asset} className="p-2 font-medium text-slate-600">{asset}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {matrix.map((row, i) => (
-            <tr key={assets[i]}> 
-              <th className="p-2 font-medium text-slate-600 text-left">{assets[i]}</th>
-              {row.map((val, j) => (
-                <td key={j} className="p-1">
-                  <div
-                    className="w-8 h-8 flex items-center justify-center rounded"
-                    style={{ backgroundColor: getColor(val) }}
-                  >
-                    {i === j ? '-' : val.toFixed(2)}
-                  </div>
-                </td>
-              ))}
-            </tr>
+    <div className="card p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900 mb-1 flex items-center">
+            <Grid className="w-5 h-5 mr-2 text-primary-600" />
+            Correlation Matrix
+          </h3>
+          <p className="text-sm text-slate-600">
+            Asset correlation analysis for {timeframe}
+          </p>
+        </div>
+        
+        {/* Timeframe Selector */}
+        <div className="flex items-center space-x-1 bg-slate-100 rounded-lg p-1">
+          {timeframes.map((tf) => (
+            <button
+              key={tf.key}
+              onClick={() => onTimeframeChange?.(tf.key)}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-200 ${
+                timeframe === tf.key
+                  ? 'bg-white text-primary-700 shadow-sm'
+                  : 'text-slate-600 hover:text-slate-900'
+              }`}
+            >
+              {tf.label}
+            </button>
           ))}
-        </tbody>
-      </table>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {/* Matrix Grid */}
+        <div className="overflow-x-auto">
+          <div className="inline-block min-w-full">
+            {/* Header Row */}
+            <div className="flex">
+              <div className="w-16 h-12"></div>
+              {symbols.map(symbol => (
+                <div key={symbol} className="w-16 h-12 flex items-center justify-center">
+                  <span className="text-xs font-semibold text-slate-700 transform -rotate-45">
+                    {symbol}
+                  </span>
+                </div>
+              ))}
+            </div>
+            
+            {/* Matrix Rows */}
+            {symbols.map((rowSymbol) => (
+              <div key={rowSymbol} className="flex">
+                {/* Row Header */}
+                <div className="w-16 h-16 flex items-center justify-center">
+                  <span className="text-xs font-semibold text-slate-700">
+                    {rowSymbol}
+                  </span>
+                </div>
+                
+                {/* Correlation Cells */}
+                {symbols.map((colSymbol) => {
+                  const correlation = getCorrelation(rowSymbol, colSymbol);
+                  const colorClass = getCorrelationColor(correlation);
+                  const isHovered = hoveredCell?.symbol1 === rowSymbol && hoveredCell?.symbol2 === colSymbol;
+                  const isSelected = selectedCell?.symbol1 === rowSymbol && selectedCell?.symbol2 === colSymbol;
+                  const isDiagonal = rowSymbol === colSymbol;
+                  
+                  return (
+                    <div
+                      key={`${rowSymbol}-${colSymbol}`}
+                      className={`w-16 h-16 flex items-center justify-center cursor-pointer transition-all duration-200 border border-slate-200 ${colorClass} ${
+                        (isHovered || isSelected) ? 'scale-110 z-10 shadow-lg rounded-lg' : ''
+                      } ${isDiagonal ? 'border-slate-400' : ''}`}
+                      onMouseEnter={() => setHoveredCell({ symbol1: rowSymbol, symbol2: colSymbol })}
+                      onMouseLeave={() => setHoveredCell(null)}
+                      onClick={() => setSelectedCell(
+                        selectedCell?.symbol1 === rowSymbol && selectedCell?.symbol2 === colSymbol 
+                          ? null 
+                          : { symbol1: rowSymbol, symbol2: colSymbol }
+                      )}
+                    >
+                      <span className="text-xs font-bold">
+                        {isDiagonal ? '1.00' : correlation.toFixed(2)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-4">
+            <span className="text-sm font-medium text-slate-700">Correlation:</span>
+            <div className="flex items-center space-x-2">
+              <div className="w-4 h-4 bg-blue-600 rounded"></div>
+              <span className="text-xs text-slate-600">-1.0 (Perfect Negative)</span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <div className="w-4 h-4 bg-slate-100 rounded border"></div>
+              <span className="text-xs text-slate-600">0.0 (No Correlation)</span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <div className="w-4 h-4 bg-red-600 rounded"></div>
+              <span className="text-xs text-slate-600">+1.0 (Perfect Positive)</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Correlation Insights */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {/* Highest Positive Correlation */}
+          {(() => {
+            const highestPositive = correlations
+              .filter(c => c.correlation > 0)
+              .sort((a, b) => b.correlation - a.correlation)[0];
+            
+            return (
+              <div className="p-4 bg-red-50 rounded-xl border border-red-200">
+                <div className="flex items-center mb-2">
+                  <TrendingUp className="w-4 h-4 text-red-600 mr-2" />
+                  <span className="text-sm font-semibold text-red-700">Highest Positive</span>
+                </div>
+                {highestPositive ? (
+                  <div>
+                    <p className="font-medium text-slate-900">
+                      {highestPositive.symbol1} - {highestPositive.symbol2}
+                    </p>
+                    <p className="text-2xl font-bold text-red-600 mb-1">
+                      {highestPositive.correlation.toFixed(3)}
+                    </p>
+                    <p className="text-xs text-slate-600">
+                      {getCorrelationLevel(highestPositive.correlation)} correlation
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-slate-500">No positive correlations</p>
+                )}
+              </div>
+            );
+          })()}
+
+          {/* Highest Negative Correlation */}
+          {(() => {
+            const highestNegative = correlations
+              .filter(c => c.correlation < 0)
+              .sort((a, b) => a.correlation - b.correlation)[0];
+            
+            return (
+              <div className="p-4 bg-blue-50 rounded-xl border border-blue-200">
+                <div className="flex items-center mb-2">
+                  <TrendingDown className="w-4 h-4 text-blue-600 mr-2" />
+                  <span className="text-sm font-semibold text-blue-700">Highest Negative</span>
+                </div>
+                {highestNegative ? (
+                  <div>
+                    <p className="font-medium text-slate-900">
+                      {highestNegative.symbol1} - {highestNegative.symbol2}
+                    </p>
+                    <p className="text-2xl font-bold text-blue-600 mb-1">
+                      {highestNegative.correlation.toFixed(3)}
+                    </p>
+                    <p className="text-xs text-slate-600">
+                      {getCorrelationLevel(highestNegative.correlation)} correlation
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-slate-500">No negative correlations</p>
+                )}
+              </div>
+            );
+          })()}
+
+          {/* Average Correlation */}
+          <div className="p-4 bg-slate-50 rounded-xl border border-slate-200">
+            <div className="flex items-center mb-2">
+              <BarChart3 className="w-4 h-4 text-slate-600 mr-2" />
+              <span className="text-sm font-semibold text-slate-700">Average Correlation</span>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-slate-900 mb-1">
+                {correlations.length > 0 
+                  ? (correlations.reduce((sum, c) => sum + Math.abs(c.correlation), 0) / correlations.length).toFixed(3)
+                  : '0.000'
+                }
+              </p>
+              <p className="text-xs text-slate-600">
+                Absolute average across all pairs
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Selected Cell Details */}
+        {selectedCell && (
+          <div className="p-4 bg-primary-50 rounded-xl border border-primary-200">
+            {(() => {
+              const corrData = getCorrelationData(selectedCell.symbol1, selectedCell.symbol2);
+              const correlation = getCorrelation(selectedCell.symbol1, selectedCell.symbol2);
+              
+              return (
+                <div>
+                  <h4 className="font-semibold text-primary-900 mb-3">
+                    {selectedCell.symbol1} - {selectedCell.symbol2} Correlation
+                  </h4>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <div>
+                      <p className="text-xs text-primary-600">Correlation</p>
+                      <p className="text-lg font-bold text-primary-900">
+                        {correlation.toFixed(3)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-primary-600">Strength</p>
+                      <p className="text-lg font-bold text-primary-900">
+                        {getCorrelationLevel(correlation)}
+                      </p>
+                    </div>
+                    {corrData && (
+                      <>
+                        <div>
+                          <p className="text-xs text-primary-600">P-Value</p>
+                          <p className="text-lg font-bold text-primary-900">
+                            {corrData.pValue.toFixed(4)}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-primary-600">Significance</p>
+                          <p className="text-lg font-bold text-primary-900 capitalize">
+                            {corrData.significance}
+                          </p>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })()}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/risk/ExposureChart.tsx
+++ b/frontend/src/components/risk/ExposureChart.tsx
@@ -1,71 +1,330 @@
-import React from 'react';
-import { BarChart3, AlertTriangle } from 'lucide-react';
+import React, { useState } from 'react';
+import { BarChart3, PieChart } from 'lucide-react';
 
-interface ExposureItem {
-  symbol: string;
+interface ExposureData {
+  category: string;
   exposure: number;
   limit: number;
+  utilizationPercent: number;
+  riskLevel: 'low' | 'medium' | 'high';
+  positions: Array<{
+    symbol: string;
+    value: number;
+    percentage: number;
+    riskContribution: number;
+  }>;
 }
 
 interface ExposureChartProps {
-  data: ExposureItem[];
+  data: ExposureData[];
   loading?: boolean;
+  chartType?: 'bar' | 'pie';
+  onChartTypeChange?: (type: 'bar' | 'pie') => void;
 }
 
-const ExposureChart: React.FC<ExposureChartProps> = ({ data, loading = false }) => {
-  const maxExposure = Math.max(...data.map(d => Math.max(d.exposure, d.limit)), 1);
+const ExposureChart: React.FC<ExposureChartProps> = ({
+  data,
+  loading = false,
+  chartType = 'bar',
+  onChartTypeChange
+}) => {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const getRiskColor = (level: 'low' | 'medium' | 'high') => {
+    switch (level) {
+      case 'low':
+        return { bg: 'bg-success-100', text: 'text-success-600', bar: 'bg-success-500' };
+      case 'medium':
+        return { bg: 'bg-warning-100', text: 'text-warning-600', bar: 'bg-warning-500' };
+      case 'high':
+        return { bg: 'bg-error-100', text: 'text-error-600', bar: 'bg-error-500' };
+    }
+  };
+
+  const formatCurrency = (value: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(value);
+  };
 
   if (loading) {
     return (
       <div className="card p-6">
-        <div className="h-6 bg-slate-200 rounded w-48 mb-4 animate-pulse"></div>
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="flex items-center space-x-3 mb-3">
-            <div className="w-16 h-4 bg-slate-200 rounded animate-pulse"></div>
-            <div className="flex-1 h-4 bg-slate-200 rounded animate-pulse"></div>
-          </div>
-        ))}
+        <div className="flex items-center justify-between mb-6">
+          <div className="h-6 bg-slate-200 rounded w-40 animate-pulse"></div>
+          <div className="h-8 bg-slate-200 rounded w-20 animate-pulse"></div>
+        </div>
+        <div className="space-y-4">
+          {[1, 2, 3, 4].map(i => (
+            <div key={i} className="animate-pulse">
+              <div className="flex justify-between mb-2">
+                <div className="h-4 bg-slate-200 rounded w-20"></div>
+                <div className="h-4 bg-slate-200 rounded w-16"></div>
+              </div>
+              <div className="h-6 bg-slate-200 rounded"></div>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }
 
+  const totalExposure = data.reduce((sum, item) => sum + item.exposure, 0);
+  const maxLimit = Math.max(...data.map(item => item.limit));
+
   return (
     <div className="card p-6">
-      <h3 className="text-lg font-semibold text-slate-900 mb-4 flex items-center">
-        <BarChart3 className="w-5 h-5 mr-2 text-primary-600" />
-        Exposure by Asset
-      </h3>
-      <div className="space-y-3">
-        {data.map(item => {
-          const pct = (item.exposure / maxExposure) * 100;
-          const limitPct = (item.limit / maxExposure) * 100;
-          const over = item.exposure > item.limit;
-          return (
-            <div key={item.symbol} className="space-y-1">
-              <div className="flex items-center justify-between text-sm">
-                <span className="font-medium text-slate-700">{item.symbol}</span>
-                <span className={`font-semibold ${over ? 'text-error-600' : 'text-slate-900'}`}>${item.exposure.toLocaleString()}</span>
-              </div>
-              <div className="relative w-full bg-slate-200 h-3 rounded-full">
-                <div
-                  className={`absolute left-0 top-0 h-3 rounded-full ${over ? 'bg-error-500' : 'bg-primary-500'}`}
-                  style={{ width: `${pct}%` }}
-                />
-                <div
-                  className="absolute top-0 h-3 rounded-full bg-slate-400 opacity-50"
-                  style={{ left: `${limitPct}%`, width: '2px' }}
-                />
-              </div>
-              {over && (
-                <div className="text-xs text-error-600 flex items-center">
-                  <AlertTriangle className="w-3 h-3 mr-1" />
-                  Over exposure limit
-                </div>
-              )}
-            </div>
-          );
-        })}
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900 mb-1 flex items-center">
+            <BarChart3 className="w-5 h-5 mr-2 text-primary-600" />
+            Risk Exposure by Category
+          </h3>
+          <p className="text-sm text-slate-600">
+            Current exposure vs limits across risk categories
+          </p>
+        </div>
+        
+        <div className="flex items-center space-x-1 bg-slate-100 rounded-lg p-1">
+          <button
+            onClick={() => onChartTypeChange?.('bar')}
+            className={`p-2 rounded-md transition-all duration-200 ${
+              chartType === 'bar'
+                ? 'bg-white text-primary-600 shadow-sm'
+                : 'text-slate-600 hover:text-slate-900'
+            }`}
+          >
+            <BarChart3 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => onChartTypeChange?.('pie')}
+            className={`p-2 rounded-md transition-all duration-200 ${
+              chartType === 'pie'
+                ? 'bg-white text-primary-600 shadow-sm'
+                : 'text-slate-600 hover:text-slate-900'
+            }`}
+          >
+            <PieChart className="w-4 h-4" />
+          </button>
+        </div>
       </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Chart */}
+        <div>
+          {chartType === 'bar' ? (
+            <div className="space-y-6">
+              {data.map((category) => {
+                const riskConfig = getRiskColor(category.riskLevel);
+                const utilizationWidth = (category.exposure / category.limit) * 100;
+                const limitWidth = (category.limit / maxLimit) * 100;
+                
+                return (
+                  <div
+                    key={category.category}
+                    className="cursor-pointer"
+                    onClick={() => setSelectedCategory(
+                      selectedCategory === category.category ? null : category.category
+                    )}
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-sm font-medium text-slate-700">
+                        {category.category}
+                      </span>
+                      <div className="flex items-center space-x-2">
+                        <span className="text-xs text-slate-500">
+                          {formatCurrency(category.exposure)} / {formatCurrency(category.limit)}
+                        </span>
+                        <span className={`px-2 py-1 text-xs font-semibold rounded-full ${riskConfig.bg} ${riskConfig.text}`}>
+                          {category.utilizationPercent.toFixed(0)}%
+                        </span>
+                      </div>
+                    </div>
+                    
+                    <div className="relative">
+                      {/* Limit background */}
+                      <div 
+                        className="h-8 bg-slate-100 rounded-lg"
+                        style={{ width: `${limitWidth}%` }}
+                      />
+                      {/* Current exposure */}
+                      <div
+                        className={`absolute top-0 h-8 rounded-lg transition-all duration-500 ${riskConfig.bar} ${
+                          selectedCategory === category.category ? 'opacity-80' : 'hover:opacity-90'
+                        }`}
+                        style={{ width: `${(utilizationWidth / 100) * limitWidth}%` }}
+                      />
+                      {/* Warning threshold line */}
+                      <div
+                        className="absolute top-0 bottom-0 w-0.5 bg-warning-500"
+                        style={{ left: `${0.8 * limitWidth}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center">
+              <svg width="280" height="280" viewBox="0 0 280 280">
+                {(() => {
+                  let cumulativePercentage = 0;
+                  const radius = 100;
+                  const centerX = 140;
+                  const centerY = 140;
+                  
+                  return data.map((category) => {
+                    const percentage = (category.exposure / totalExposure) * 100;
+                    const startAngle = (cumulativePercentage * 360) / 100;
+                    const endAngle = ((cumulativePercentage + percentage) * 360) / 100;
+                    
+                    const startAngleRad = (startAngle * Math.PI) / 180;
+                    const endAngleRad = (endAngle * Math.PI) / 180;
+                    
+                    const largeArcFlag = percentage > 50 ? 1 : 0;
+                    
+                    const x1 = centerX + radius * Math.cos(startAngleRad);
+                    const y1 = centerY + radius * Math.sin(startAngleRad);
+                    const x2 = centerX + radius * Math.cos(endAngleRad);
+                    const y2 = centerY + radius * Math.sin(endAngleRad);
+                    
+                    const pathData = [
+                      `M ${centerX} ${centerY}`,
+                      `L ${x1} ${y1}`,
+                      `A ${radius} ${radius} 0 ${largeArcFlag} 1 ${x2} ${y2}`,
+                      'Z'
+                    ].join(' ');
+
+                    cumulativePercentage += percentage;
+                    
+                    const riskConfig = getRiskColor(category.riskLevel);
+                    const color = riskConfig.bar.includes('success') ? '#22c55e' : 
+                                  riskConfig.bar.includes('warning') ? '#f59e0b' : '#ef4444';
+
+                    return (
+                      <path
+                        key={category.category}
+                        d={pathData}
+                        fill={color}
+                        stroke="white"
+                        strokeWidth="2"
+                        className={`cursor-pointer transition-all duration-200 ${
+                          selectedCategory === category.category ? 'opacity-80' : 'hover:opacity-80'
+                        }`}
+                        onClick={() => setSelectedCategory(
+                          selectedCategory === category.category ? null : category.category
+                        )}
+                      />
+                    );
+                  });
+                })()}
+                
+                {/* Center circle */}
+                <circle cx="140" cy="140" r="40" fill="white" stroke="#e2e8f0" strokeWidth="2" />
+                <text x="140" y="135" textAnchor="middle" className="text-sm font-semibold fill-slate-900">
+                  Risk
+                </text>
+                <text x="140" y="150" textAnchor="middle" className="text-xs fill-slate-500">
+                  Exposure
+                </text>
+              </svg>
+            </div>
+          )}
+        </div>
+
+        {/* Categories List */}
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium text-slate-700 mb-4">Exposure Categories</h4>
+          <div className="space-y-3 max-h-80 overflow-y-auto scrollbar-hide">
+            {data.map((category) => {
+              const riskConfig = getRiskColor(category.riskLevel);
+              const isSelected = selectedCategory === category.category;
+              
+              return (
+                <div
+                  key={category.category}
+                  className={`p-4 rounded-xl border transition-all duration-200 cursor-pointer ${
+                    isSelected
+                      ? 'border-primary-200 bg-primary-50'
+                      : 'border-slate-200 bg-slate-50 hover:border-slate-300'
+                  }`}
+                  onClick={() => setSelectedCategory(isSelected ? null : category.category)}
+                >
+                  <div className="flex items-center justify-between mb-3">
+                    <h5 className="font-medium text-slate-900">{category.category}</h5>
+                    <span className={`px-2.5 py-1 text-xs font-semibold rounded-lg ${riskConfig.bg} ${riskConfig.text}`}>
+                      {category.riskLevel.toUpperCase()}
+                    </span>
+                  </div>
+                  
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <p className="text-slate-500">Exposure</p>
+                      <p className="font-semibold text-slate-900">{formatCurrency(category.exposure)}</p>
+                    </div>
+                    <div>
+                      <p className="text-slate-500">Limit</p>
+                      <p className="font-semibold text-slate-900">{formatCurrency(category.limit)}</p>
+                    </div>
+                    <div>
+                      <p className="text-slate-500">Utilization</p>
+                      <p className={`font-semibold ${riskConfig.text}`}>
+                        {category.utilizationPercent.toFixed(1)}%
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-slate-500">Positions</p>
+                      <p className="font-semibold text-slate-900">{category.positions.length}</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Selected Category Details */}
+      {selectedCategory && (
+        <div className="mt-6 pt-6 border-t border-slate-200">
+          {(() => {
+            const selected = data.find(cat => cat.category === selectedCategory);
+            if (!selected) return null;
+            
+            return (
+              <div>
+                <h4 className="text-lg font-semibold text-slate-900 mb-4">
+                  {selected.category} - Position Details
+                </h4>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {selected.positions.map((position) => (
+                    <div key={position.symbol} className="p-4 bg-slate-50 rounded-xl">
+                      <div className="flex items-center justify-between mb-2">
+                        <span className="font-semibold text-slate-900">{position.symbol}</span>
+                        <span className="text-sm text-slate-600">{position.percentage.toFixed(1)}%</span>
+                      </div>
+                      <div className="space-y-1 text-sm">
+                        <div className="flex justify-between">
+                          <span className="text-slate-500">Value:</span>
+                          <span className="text-slate-900">{formatCurrency(position.value)}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-slate-500">Risk Contribution:</span>
+                          <span className="text-slate-900">{position.riskContribution.toFixed(2)}%</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/risk/RiskAlerts.tsx
+++ b/frontend/src/components/risk/RiskAlerts.tsx
@@ -1,66 +1,414 @@
-import React from 'react';
-import { AlertTriangle, CheckCircle2, Bell, Clock } from 'lucide-react';
+import React, { useState } from 'react';
+import {
+  AlertTriangle, Shield, Clock, CheckCircle, XCircle,
+  Bell, Settings, X, Eye, EyeOff, Activity, TrendingUp,
+  BarChart3, Target, Globe
+} from 'lucide-react';
 
-interface AlertItem {
+interface RiskAlert {
   id: string;
-  message: string;
-  severity: 'low' | 'medium' | 'high' | 'critical';
+  type: 'warning' | 'critical' | 'info';
+  category: 'exposure' | 'correlation' | 'volatility' | 'margin' | 'position' | 'market';
+  title: string;
+  description: string;
   timestamp: string;
+  isRead: boolean;
+  isAcknowledged: boolean;
+  affectedPositions?: string[];
+  recommendedAction?: string;
+  severity: number; // 1-10 scale
 }
 
 interface RiskAlertsProps {
-  alerts: AlertItem[];
+  alerts: RiskAlert[];
+  onMarkAsRead: (alertId: string) => void;
+  onAcknowledge: (alertId: string) => void;
+  onDismiss: (alertId: string) => void;
   loading?: boolean;
 }
 
-const severityStyles: Record<AlertItem['severity'], { bg: string; text: string; icon: React.ReactNode }> = {
-  low: { bg: 'bg-success-50', text: 'text-success-700', icon: <CheckCircle2 className="w-4 h-4" /> },
-  medium: { bg: 'bg-warning-50', text: 'text-warning-700', icon: <Bell className="w-4 h-4" /> },
-  high: { bg: 'bg-error-50', text: 'text-error-700', icon: <AlertTriangle className="w-4 h-4" /> },
-  critical: { bg: 'bg-error-100', text: 'text-error-800', icon: <AlertTriangle className="w-4 h-4" /> },
-};
+const RiskAlerts: React.FC<RiskAlertsProps> = ({
+  alerts,
+  onMarkAsRead,
+  onAcknowledge,
+  onDismiss,
+  loading = false
+}) => {
+  const [showOnlyUnread, setShowOnlyUnread] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [selectedAlert, setSelectedAlert] = useState<RiskAlert | null>(null);
 
-const RiskAlerts: React.FC<RiskAlertsProps> = ({ alerts, loading = false }) => {
+  const getAlertConfig = (type: RiskAlert['type']) => {
+    switch (type) {
+      case 'critical':
+        return {
+          icon: XCircle,
+          bg: 'bg-error-50',
+          border: 'border-error-200',
+          text: 'text-error-700',
+          iconColor: 'text-error-500'
+        };
+      case 'warning':
+        return {
+          icon: AlertTriangle,
+          bg: 'bg-warning-50',
+          border: 'border-warning-200',
+          text: 'text-warning-700',
+          iconColor: 'text-warning-500'
+        };
+      case 'info':
+        return {
+          icon: Shield,
+          bg: 'bg-primary-50',
+          border: 'border-primary-200',
+          text: 'text-primary-700',
+          iconColor: 'text-primary-500'
+        };
+    }
+  };
+
+  const getCategoryIcon = (category: RiskAlert['category']) => {
+    const icons = {
+      exposure: Shield,
+      correlation: Activity,
+      volatility: TrendingUp,
+      margin: BarChart3,
+      position: Target,
+      market: Globe
+    };
+    return icons[category] || Shield;
+  };
+
+  const formatTime = (timestamp: string) => {
+    const now = new Date();
+    const alertTime = new Date(timestamp);
+    const diffMs = now.getTime() - alertTime.getTime();
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    
+    if (diffMinutes < 1) return 'Just now';
+    if (diffMinutes < 60) return `${diffMinutes}m ago`;
+    if (diffMinutes < 1440) return `${Math.floor(diffMinutes / 60)}h ago`;
+    return alertTime.toLocaleDateString();
+  };
+
+  const filteredAlerts = alerts.filter(alert => {
+    if (showOnlyUnread && alert.isRead) return false;
+    if (selectedCategory !== 'all' && alert.category !== selectedCategory) return false;
+    return true;
+  });
+
+  const unreadCount = alerts.filter(alert => !alert.isRead).length;
+  const criticalCount = alerts.filter(alert => alert.type === 'critical').length;
+
   if (loading) {
     return (
       <div className="card p-6">
-        <div className="h-6 bg-slate-200 rounded w-40 mb-4 animate-pulse"></div>
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="flex items-center space-x-3 py-2 border-b border-slate-200 last:border-0">
-            <div className="w-4 h-4 bg-slate-200 rounded-full animate-pulse"></div>
-            <div className="flex-1 h-4 bg-slate-200 rounded animate-pulse"></div>
-          </div>
-        ))}
+        <div className="flex items-center justify-between mb-6">
+          <div className="h-6 bg-slate-200 rounded w-32 animate-pulse"></div>
+          <div className="h-8 bg-slate-200 rounded w-24 animate-pulse"></div>
+        </div>
+        <div className="space-y-4">
+          {[1, 2, 3].map(i => (
+            <div key={i} className="p-4 border border-slate-200 rounded-xl animate-pulse">
+              <div className="flex items-start space-x-3">
+                <div className="w-10 h-10 bg-slate-200 rounded-lg"></div>
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 bg-slate-200 rounded w-3/4"></div>
+                  <div className="h-3 bg-slate-200 rounded w-1/2"></div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }
 
   return (
     <div className="card p-6">
-      <h3 className="text-lg font-semibold text-slate-900 mb-4 flex items-center">
-        <AlertTriangle className="w-5 h-5 mr-2 text-error-600" />
-        Risk Alerts
-      </h3>
-      <div className="divide-y divide-slate-200">
-        {alerts.map(alert => {
-          const style = severityStyles[alert.severity];
-          return (
-            <div key={alert.id} className="flex items-start py-3">
-              <div className={`p-2 rounded-full mr-3 ${style.bg} ${style.text}`}>{style.icon}</div>
-              <div className="flex-1">
-                <p className="text-sm font-medium text-slate-900">{alert.message}</p>
-                <p className="text-xs text-slate-500 flex items-center mt-1">
-                  <Clock className="w-3 h-3 mr-1" />
-                  {new Date(alert.timestamp).toLocaleString()}
-                </p>
-              </div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900 mb-1 flex items-center">
+            <Bell className="w-5 h-5 mr-2 text-primary-600" />
+            Risk Alerts
+            {unreadCount > 0 && (
+              <span className="ml-2 bg-error-100 text-error-700 text-xs font-semibold px-2 py-1 rounded-full">
+                {unreadCount} new
+              </span>
+            )}
+          </h3>
+          <p className="text-sm text-slate-600">
+            {criticalCount > 0 && (
+              <span className="text-error-600 font-medium">
+                {criticalCount} critical alert{criticalCount > 1 ? 's' : ''} require attention
+              </span>
+            )}
+            {criticalCount === 0 && 'All systems operating normally'}
+          </p>
+        </div>
+        
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={() => setShowOnlyUnread(!showOnlyUnread)}
+            className={`btn-ghost text-sm ${showOnlyUnread ? 'bg-primary-50 text-primary-700' : ''}`}
+          >
+            {showOnlyUnread ? <Eye className="w-4 h-4 mr-1" /> : <EyeOff className="w-4 h-4 mr-1" />}
+            {showOnlyUnread ? 'Show All' : 'Unread Only'}
+          </button>
+          
+          <select
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+            className="text-sm border border-slate-300 rounded-lg px-3 py-2 bg-white"
+          >
+            <option value="all">All Categories</option>
+            <option value="exposure">Exposure</option>
+            <option value="correlation">Correlation</option>
+            <option value="volatility">Volatility</option>
+            <option value="margin">Margin</option>
+            <option value="position">Position</option>
+            <option value="market">Market</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Alerts List */}
+      <div className="space-y-3 max-h-96 overflow-y-auto scrollbar-hide">
+        {filteredAlerts.length === 0 ? (
+          <div className="text-center py-8">
+            <div className="w-16 h-16 bg-success-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <CheckCircle className="h-8 w-8 text-success-600" />
             </div>
-          );
-        })}
-        {alerts.length === 0 && (
-          <p className="text-sm text-slate-500 py-4 text-center">No active risk alerts</p>
+            <h4 className="text-lg font-semibold text-slate-900 mb-2">No Active Alerts</h4>
+            <p className="text-slate-600">
+              {showOnlyUnread 
+                ? "You're all caught up! No unread alerts."
+                : "All risk parameters are within acceptable limits."
+              }
+            </p>
+          </div>
+        ) : (
+          filteredAlerts.map((alert) => {
+            const config = getAlertConfig(alert.type);
+            const Icon = config.icon;
+            const CategoryIcon = getCategoryIcon(alert.category);
+            
+            return (
+              <div
+                key={alert.id}
+                className={`relative p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer hover:shadow-sm ${
+                  config.border
+                } ${config.bg} ${
+                  !alert.isRead ? 'border-l-4 border-l-primary-500' : ''
+                }`}
+                onClick={() => setSelectedAlert(alert)}
+              >
+                <div className="flex items-start space-x-3">
+                  {/* Alert Icon */}
+                  <div className="flex-shrink-0">
+                    <Icon className={`w-6 h-6 ${config.iconColor}`} />
+                  </div>
+                  
+                  {/* Alert Content */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between mb-2">
+                      <h4 className={`font-semibold ${config.text}`}>
+                        {alert.title}
+                      </h4>
+                      <div className="flex items-center space-x-2 ml-4">
+                        <CategoryIcon className="w-4 h-4 text-slate-400" />
+                        <span className="text-xs text-slate-500 uppercase tracking-wide">
+                          {alert.category}
+                        </span>
+                      </div>
+                    </div>
+                    
+                    <p className="text-sm text-slate-600 mb-3 line-clamp-2">
+                      {alert.description}
+                    </p>
+                    
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-4">
+                        <span className="text-xs text-slate-500">
+                          {formatTime(alert.timestamp)}
+                        </span>
+                        
+                        {alert.affectedPositions && alert.affectedPositions.length > 0 && (
+                          <div className="flex items-center space-x-1">
+                            <span className="text-xs text-slate-500">Affects:</span>
+                            {alert.affectedPositions.slice(0, 3).map((symbol) => (
+                              <span
+                                key={symbol}
+                                className="text-xs bg-slate-200 text-slate-700 px-2 py-1 rounded"
+                              >
+                                {symbol}
+                              </span>
+                            ))}
+                            {alert.affectedPositions.length > 3 && (
+                              <span className="text-xs text-slate-500">
+                                +{alert.affectedPositions.length - 3} more
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      
+                      {/* Severity Indicator */}
+                      <div className="flex items-center space-x-1">
+                        {Array.from({ length: 5 }).map((_, i) => (
+                          <div
+                            key={i}
+                            className={`w-1 h-4 rounded ${
+                              i < Math.ceil(alert.severity / 2) 
+                                ? alert.severity > 7 ? 'bg-error-500' : alert.severity > 4 ? 'bg-warning-500' : 'bg-success-500'
+                                : 'bg-slate-200'
+                            }`}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                  
+                  {/* Action Buttons */}
+                  <div className="flex items-center space-x-1">
+                    {!alert.isRead && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onMarkAsRead(alert.id);
+                        }}
+                        className="p-1 rounded text-slate-400 hover:text-slate-600 transition-colors"
+                        title="Mark as read"
+                      >
+                        <Eye className="w-4 h-4" />
+                      </button>
+                    )}
+                    
+                    {!alert.isAcknowledged && alert.type !== 'info' && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onAcknowledge(alert.id);
+                        }}
+                        className="p-1 rounded text-slate-400 hover:text-slate-600 transition-colors"
+                        title="Acknowledge"
+                      >
+                        <CheckCircle className="w-4 h-4" />
+                      </button>
+                    )}
+                    
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDismiss(alert.id);
+                      }}
+                      className="p-1 rounded text-slate-400 hover:text-error-600 transition-colors"
+                      title="Dismiss"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Recommended Action */}
+                {alert.recommendedAction && (
+                  <div className="mt-3 pt-3 border-t border-slate-200">
+                    <div className="flex items-start space-x-2">
+                      <Settings className="w-4 h-4 text-slate-400 mt-0.5" />
+                      <div>
+                        <p className="text-xs font-medium text-slate-700 mb-1">Recommended Action:</p>
+                        <p className="text-xs text-slate-600">{alert.recommendedAction}</p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })
         )}
       </div>
+
+      {/* Alert Detail Modal */}
+      {selectedAlert && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+            <div
+              className="fixed inset-0 transition-opacity bg-slate-500 bg-opacity-75"
+              onClick={() => setSelectedAlert(null)}
+            />
+            
+            <div className="inline-block w-full max-w-md my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+              <div className="p-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-lg font-semibold text-slate-900">Alert Details</h3>
+                  <button
+                    onClick={() => setSelectedAlert(null)}
+                    className="p-1 rounded text-slate-400 hover:text-slate-600"
+                  >
+                    <X className="w-5 h-5" />
+                  </button>
+                </div>
+                
+                <div className="space-y-4">
+                  <div>
+                    <h4 className="font-semibold text-slate-900 mb-1">{selectedAlert.title}</h4>
+                    <p className="text-sm text-slate-600">{selectedAlert.description}</p>
+                  </div>
+                  
+                  {selectedAlert.affectedPositions && (
+                    <div>
+                      <h5 className="text-sm font-medium text-slate-700 mb-2">Affected Positions:</h5>
+                      <div className="flex flex-wrap gap-1">
+                        {selectedAlert.affectedPositions.map(symbol => (
+                          <span key={symbol} className="text-xs bg-slate-100 text-slate-700 px-2 py-1 rounded">
+                            {symbol}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  
+                  {selectedAlert.recommendedAction && (
+                    <div>
+                      <h5 className="text-sm font-medium text-slate-700 mb-2">Recommended Action:</h5>
+                      <p className="text-sm text-slate-600">{selectedAlert.recommendedAction}</p>
+                    </div>
+                  )}
+                  
+                  <div className="flex items-center justify-between pt-4 border-t border-slate-200">
+                    <span className="text-xs text-slate-500">
+                      {formatTime(selectedAlert.timestamp)}
+                    </span>
+                    <div className="flex items-center space-x-2">
+                      {!selectedAlert.isAcknowledged && selectedAlert.type !== 'info' && (
+                        <button
+                          onClick={() => {
+                            onAcknowledge(selectedAlert.id);
+                            setSelectedAlert(null);
+                          }}
+                          className="btn-primary text-sm"
+                        >
+                          Acknowledge
+                        </button>
+                      )}
+                      <button
+                        onClick={() => {
+                          onDismiss(selectedAlert.id);
+                          setSelectedAlert(null);
+                        }}
+                        className="btn-secondary text-sm"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/RiskDashboard.tsx
+++ b/frontend/src/pages/RiskDashboard.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { Shield, RefreshCw, Download, Settings } from 'lucide-react';
+import {
+  Shield, Activity, BarChart3,
+  RefreshCw, Download, Settings, Bell
+} from 'lucide-react';
 import RiskMetrics from '../components/risk/RiskMetrics';
 import ExposureChart from '../components/risk/ExposureChart';
 import RiskAlerts from '../components/risk/RiskAlerts';
 import CorrelationMatrix from '../components/risk/CorrelationMatrix';
 
-interface RiskData {
+interface RiskDashboardData {
   metrics: {
     portfolioVaR: number;
     portfolioCVaR: number;
@@ -20,55 +23,165 @@ interface RiskData {
     riskScore: number;
     riskLevel: 'low' | 'medium' | 'high' | 'critical';
   };
-  exposures: Array<{ symbol: string; exposure: number; limit: number }>;
-  alerts: Array<{ id: string; message: string; severity: 'low' | 'medium' | 'high' | 'critical'; timestamp: string }>;
-  correlation: { assets: string[]; matrix: number[][] };
+  exposure: Array<{
+    category: string;
+    exposure: number;
+    limit: number;
+    utilizationPercent: number;
+    riskLevel: 'low' | 'medium' | 'high';
+    positions: Array<{
+      symbol: string;
+      value: number;
+      percentage: number;
+      riskContribution: number;
+    }>;
+  }>;
+  alerts: Array<{
+    id: string;
+    type: 'warning' | 'critical' | 'info';
+    category: 'exposure' | 'correlation' | 'volatility' | 'margin' | 'position' | 'market';
+    title: string;
+    description: string;
+    timestamp: string;
+    isRead: boolean;
+    isAcknowledged: boolean;
+    affectedPositions?: string[];
+    recommendedAction?: string;
+    severity: number;
+  }>;
+  correlations: {
+    symbols: string[];
+    data: Array<{
+      symbol1: string;
+      symbol2: string;
+      correlation: number;
+      pValue: number;
+      significance: 'high' | 'medium' | 'low';
+    }>;
+  };
 }
 
 const RiskDashboard: React.FC = () => {
-  const [data, setData] = useState<RiskData | null>(null);
+  const [data, setData] = useState<RiskDashboardData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [selectedTab, setSelectedTab] = useState<'overview' | 'exposure' | 'alerts' | 'correlation'>('overview');
+  const [autoRefresh, setAutoRefresh] = useState(true);
 
   const fetchRiskData = async () => {
     try {
       setLoading(true);
-      // Mock data
-      const mock: RiskData = {
+      
+      // Mock data - replace with real API calls
+      const mockData: RiskDashboardData = {
         metrics: {
-          portfolioVaR: 5.6,
-          portfolioCVaR: 8.2,
-          positionLimit: 20,
-          usedPositions: 12,
-          marginUtilization: 54.3,
-          leverageRatio: 1.4,
-          correlationRisk: 32.5,
-          concentrationRisk: 18.7,
-          liquidityRisk: 14.2,
-          marketRisk: 22.1,
-          riskScore: 62,
+          portfolioVaR: 2.8,
+          portfolioCVaR: 4.2,
+          positionLimit: 10,
+          usedPositions: 7,
+          marginUtilization: 45.3,
+          leverageRatio: 1.8,
+          correlationRisk: 35.7,
+          concentrationRisk: 28.4,
+          liquidityRisk: 12.1,
+          marketRisk: 18.9,
+          riskScore: 72,
           riskLevel: 'medium'
         },
-        exposures: [
-          { symbol: 'AAPL', exposure: 25000, limit: 30000 },
-          { symbol: 'TSLA', exposure: 20000, limit: 15000 },
-          { symbol: 'MSFT', exposure: 12000, limit: 20000 },
-          { symbol: 'NVDA', exposure: 8000, limit: 10000 }
+        exposure: [
+          {
+            category: 'Technology',
+            exposure: 85000,
+            limit: 120000,
+            utilizationPercent: 70.8,
+            riskLevel: 'medium',
+            positions: [
+              { symbol: 'AAPL', value: 45000, percentage: 52.9, riskContribution: 15.2 },
+              { symbol: 'GOOGL', value: 25000, percentage: 29.4, riskContribution: 8.9 },
+              { symbol: 'MSFT', value: 15000, percentage: 17.6, riskContribution: 6.1 }
+            ]
+          },
+          {
+            category: 'Healthcare',
+            exposure: 35000,
+            limit: 60000,
+            utilizationPercent: 58.3,
+            riskLevel: 'low',
+            positions: [
+              { symbol: 'JNJ', value: 20000, percentage: 57.1, riskContribution: 4.2 },
+              { symbol: 'PFE', value: 15000, percentage: 42.9, riskContribution: 3.1 }
+            ]
+          },
+          {
+            category: 'Financial',
+            exposure: 28000,
+            limit: 40000,
+            utilizationPercent: 70.0,
+            riskLevel: 'medium',
+            positions: [
+              { symbol: 'JPM', value: 18000, percentage: 64.3, riskContribution: 5.8 },
+              { symbol: 'BAC', value: 10000, percentage: 35.7, riskContribution: 2.9 }
+            ]
+          }
         ],
         alerts: [
-          { id: '1', message: 'TSLA exposure exceeds limit', severity: 'high', timestamp: new Date().toISOString() },
-          { id: '2', message: 'Portfolio VaR approaching threshold', severity: 'medium', timestamp: new Date().toISOString() }
+          {
+            id: '1',
+            type: 'critical',
+            category: 'exposure',
+            title: 'Technology Sector Over-Concentration',
+            description: 'Technology sector exposure has exceeded 65% of portfolio, increasing concentration risk.',
+            timestamp: new Date(Date.now() - 1800000).toISOString(),
+            isRead: false,
+            isAcknowledged: false,
+            affectedPositions: ['AAPL', 'GOOGL', 'MSFT'],
+            recommendedAction: 'Consider reducing technology positions or diversifying into other sectors.',
+            severity: 8
+          },
+          {
+            id: '2',
+            type: 'warning',
+            category: 'correlation',
+            title: 'High Correlation Detected',
+            description: 'AAPL and MSFT showing correlation above 0.8, increasing portfolio risk.',
+            timestamp: new Date(Date.now() - 3600000).toISOString(),
+            isRead: false,
+            isAcknowledged: false,
+            affectedPositions: ['AAPL', 'MSFT'],
+            recommendedAction: 'Monitor correlation trends and consider position adjustments.',
+            severity: 6
+          },
+          {
+            id: '3',
+            type: 'info',
+            category: 'volatility',
+            title: 'Market Volatility Increase',
+            description: 'Market volatility has increased by 15% over the past week.',
+            timestamp: new Date(Date.now() - 7200000).toISOString(),
+            isRead: true,
+            isAcknowledged: true,
+            severity: 4
+          }
         ],
-        correlation: {
-          assets: ['AAPL', 'TSLA', 'MSFT', 'NVDA'],
-          matrix: [
-            [1, 0.6, 0.8, 0.7],
-            [0.6, 1, 0.5, 0.4],
-            [0.8, 0.5, 1, 0.6],
-            [0.7, 0.4, 0.6, 1]
+        correlations: {
+          symbols: ['AAPL', 'GOOGL', 'MSFT', 'JNJ', 'JPM'],
+          data: [
+            { symbol1: 'AAPL', symbol2: 'GOOGL', correlation: 0.67, pValue: 0.001, significance: 'high' },
+            { symbol1: 'AAPL', symbol2: 'MSFT', correlation: 0.82, pValue: 0.000, significance: 'high' },
+            { symbol1: 'AAPL', symbol2: 'JNJ', correlation: 0.23, pValue: 0.087, significance: 'low' },
+            { symbol1: 'AAPL', symbol2: 'JPM', correlation: 0.45, pValue: 0.012, significance: 'medium' },
+            { symbol1: 'GOOGL', symbol2: 'MSFT', correlation: 0.71, pValue: 0.002, significance: 'high' },
+            { symbol1: 'GOOGL', symbol2: 'JNJ', correlation: 0.18, pValue: 0.156, significance: 'low' },
+            { symbol1: 'GOOGL', symbol2: 'JPM', correlation: 0.39, pValue: 0.028, significance: 'medium' },
+            { symbol1: 'MSFT', symbol2: 'JNJ', correlation: 0.15, pValue: 0.234, significance: 'low' },
+            { symbol1: 'MSFT', symbol2: 'JPM', correlation: 0.41, pValue: 0.021, significance: 'medium' },
+            { symbol1: 'JNJ', symbol2: 'JPM', correlation: -0.12, pValue: 0.367, significance: 'low' }
           ]
         }
       };
-      setData(mock);
+      
+      setData(mockData);
+    } catch (error) {
+      console.error('Error fetching risk data:', error);
     } finally {
       setLoading(false);
     }
@@ -76,13 +189,59 @@ const RiskDashboard: React.FC = () => {
 
   useEffect(() => {
     fetchRiskData();
-    const interval = setInterval(fetchRiskData, 300000);
-    return () => clearInterval(interval);
-  }, []);
+    
+    // Auto-refresh every 2 minutes if enabled
+    let interval: NodeJS.Timeout | null = null;
+    if (autoRefresh) {
+      interval = setInterval(fetchRiskData, 120000);
+    }
+    
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [autoRefresh]);
 
-  const exportData = () => {
-    console.log('Exporting risk data...');
+  const handleMarkAsRead = async (alertId: string) => {
+    if (!data) return;
+    
+    setData({
+      ...data,
+      alerts: data.alerts.map(alert =>
+        alert.id === alertId ? { ...alert, isRead: true } : alert
+      )
+    });
   };
+
+  const handleAcknowledge = async (alertId: string) => {
+    if (!data) return;
+    
+    setData({
+      ...data,
+      alerts: data.alerts.map(alert =>
+        alert.id === alertId ? { ...alert, isAcknowledged: true, isRead: true } : alert
+      )
+    });
+  };
+
+  const handleDismiss = async (alertId: string) => {
+    if (!data) return;
+    
+    setData({
+      ...data,
+      alerts: data.alerts.filter(alert => alert.id !== alertId)
+    });
+  };
+
+  const exportRiskReport = () => {
+    console.log('Exporting risk report...');
+  };
+
+  const tabs = [
+    { key: 'overview', label: 'Overview', icon: Shield },
+    { key: 'exposure', label: 'Exposure', icon: BarChart3 },
+    { key: 'alerts', label: 'Alerts', icon: Bell },
+    { key: 'correlation', label: 'Correlation', icon: Activity }
+  ];
 
   if (loading && !data) {
     return (
@@ -92,11 +251,14 @@ const RiskDashboard: React.FC = () => {
             <Shield className="w-8 h-8 text-white" />
           </div>
           <h2 className="text-2xl font-bold text-slate-900 mb-2">Loading Risk Dashboard</h2>
-          <p className="text-slate-600">Assessing portfolio risk...</p>
+          <p className="text-slate-600">Analyzing portfolio risk metrics...</p>
         </div>
       </div>
     );
   }
+
+  const unreadAlertsCount = data?.alerts.filter(alert => !alert.isRead).length || 0;
+  const criticalAlertsCount = data?.alerts.filter(alert => alert.type === 'critical').length || 0;
 
   return (
     <div className="min-h-screen bg-slate-50 p-6">
@@ -104,35 +266,302 @@ const RiskDashboard: React.FC = () => {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-slate-900">Risk Dashboard</h1>
-            <p className="text-slate-600 mt-1">Real-time risk analysis and alerts</p>
+            <h1 className="text-3xl font-bold text-slate-900">Risk Management</h1>
+            <p className="text-slate-600 mt-1">
+              Real-time risk monitoring and portfolio protection
+              {criticalAlertsCount > 0 && (
+                <span className="ml-2 text-error-600 font-semibold">
+                  • {criticalAlertsCount} critical alert{criticalAlertsCount > 1 ? 's' : ''}
+                </span>
+              )}
+            </p>
           </div>
+          
           <div className="flex items-center space-x-3">
-            <button onClick={exportData} className="btn-ghost">
-              <Download className="w-4 h-4 mr-2" />
-              Export
+            <button
+              onClick={() => setAutoRefresh(!autoRefresh)}
+              className={`btn-ghost ${autoRefresh ? 'bg-primary-50 text-primary-700' : ''}`}
+            >
+              <RefreshCw className={`w-4 h-4 mr-2 ${autoRefresh ? 'animate-spin' : ''}`} />
+              Auto Refresh
             </button>
+            
+            <button onClick={exportRiskReport} className="btn-ghost">
+              <Download className="w-4 h-4 mr-2" />
+              Export Report
+            </button>
+            
             <button onClick={fetchRiskData} className="btn-secondary">
               <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
               Refresh
             </button>
+            
             <button className="btn-ghost">
               <Settings className="w-4 h-4 mr-2" />
-              Settings
+              Risk Settings
             </button>
           </div>
         </div>
 
-        {data && (
+        {/* Tab Navigation */}
+        <div className="card p-2">
+          <div className="flex items-center space-x-1">
+            {tabs.map((tab) => {
+              const Icon = tab.icon;
+              const alertCount = tab.key === 'alerts' ? unreadAlertsCount : 0;
+              
+              return (
+                <button
+                  key={tab.key}
+                  onClick={() => setSelectedTab(tab.key as any)}
+                  className={`flex items-center px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 relative ${
+                    selectedTab === tab.key
+                      ? 'bg-primary-100 text-primary-700 shadow-sm'
+                      : 'text-slate-600 hover:text-slate-900 hover:bg-slate-50'
+                  }`}
+                >
+                  <Icon className="w-4 h-4 mr-2" />
+                  {tab.label}
+                  {alertCount > 0 && (
+                    <span className="ml-2 bg-error-500 text-white text-xs font-bold px-2 py-1 rounded-full min-w-[18px] h-[18px] flex items-center justify-center">
+                      {alertCount > 9 ? '9+' : alertCount}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Tab Content */}
+        {selectedTab === 'overview' && data && (
           <div className="space-y-6">
             <RiskMetrics metrics={data.metrics} loading={loading} />
+            
+            {/* Quick Overview Grid */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <ExposureChart data={data.exposures} loading={loading} />
-              <CorrelationMatrix assets={data.correlation.assets} matrix={data.correlation.matrix} loading={loading} />
+              <ExposureChart 
+                data={data.exposure} 
+                loading={loading}
+                chartType="bar"
+              />
+              
+              <RiskAlerts
+                alerts={data.alerts.slice(0, 5)}
+                onMarkAsRead={handleMarkAsRead}
+                onAcknowledge={handleAcknowledge}
+                onDismiss={handleDismiss}
+                loading={loading}
+              />
             </div>
-            <RiskAlerts alerts={data.alerts} loading={loading} />
           </div>
         )}
+
+        {selectedTab === 'exposure' && data && (
+          <div className="space-y-6">
+            <ExposureChart 
+              data={data.exposure} 
+              loading={loading}
+              chartType="bar"
+            />
+            
+            {/* Detailed Exposure Analysis */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="card p-6">
+                <h4 className="text-lg font-semibold text-slate-900 mb-4">Sector Concentration</h4>
+                <div className="space-y-3">
+                  {data.exposure.map((category) => (
+                    <div key={category.category} className="flex items-center justify-between">
+                      <span className="text-sm text-slate-600">{category.category}</span>
+                      <div className="flex items-center space-x-2">
+                        <span className="text-sm font-semibold text-slate-900">
+                          {category.utilizationPercent.toFixed(1)}%
+                        </span>
+                        <div className={`w-3 h-3 rounded-full ${
+                          category.riskLevel === 'high' ? 'bg-error-500' :
+                          category.riskLevel === 'medium' ? 'bg-warning-500' : 'bg-success-500'
+                        }`} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="card p-6">
+                <h4 className="text-lg font-semibold text-slate-900 mb-4">Risk Limits</h4>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-slate-600">Position Limit</span>
+                    <span className="text-sm font-semibold text-slate-900">
+                      {data.metrics.usedPositions}/{data.metrics.positionLimit}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-slate-600">Margin Usage</span>
+                    <span className="text-sm font-semibold text-slate-900">
+                      {data.metrics.marginUtilization.toFixed(1)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-slate-600">Leverage Ratio</span>
+                    <span className="text-sm font-semibold text-slate-900">
+                      {data.metrics.leverageRatio.toFixed(2)}x
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="card p-6">
+                <h4 className="text-lg font-semibold text-slate-900 mb-4">Risk Metrics</h4>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-slate-600">Portfolio VaR</span>
+                    <span className="text-sm font-semibold text-error-600">
+                      {data.metrics.portfolioVaR.toFixed(2)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-slate-600">CVaR (ES)</span>
+                    <span className="text-sm font-semibold text-error-600">
+                      {data.metrics.portfolioCVaR.toFixed(2)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-slate-600">Correlation Risk</span>
+                    <span className="text-sm font-semibold text-warning-600">
+                      {data.metrics.correlationRisk.toFixed(1)}%
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {selectedTab === 'alerts' && data && (
+          <div className="space-y-6">
+            <RiskAlerts
+              alerts={data.alerts}
+              onMarkAsRead={handleMarkAsRead}
+              onAcknowledge={handleAcknowledge}
+              onDismiss={handleDismiss}
+              loading={loading}
+            />
+          </div>
+        )}
+
+        {selectedTab === 'correlation' && data && (
+          <div className="space-y-6">
+            <CorrelationMatrix
+              symbols={data.correlations.symbols}
+              correlations={data.correlations.data}
+              loading={loading}
+              timeframe="3M"
+            />
+            
+            {/* Correlation Insights */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="card p-6">
+                <h4 className="text-lg font-semibold text-slate-900 mb-4">High Risk Correlations</h4>
+                <div className="space-y-3">
+                  {data.correlations.data
+                    .filter(c => Math.abs(c.correlation) > 0.7)
+                    .sort((a, b) => Math.abs(b.correlation) - Math.abs(a.correlation))
+                    .slice(0, 5)
+                    .map((correlation) => (
+                      <div key={`${correlation.symbol1}-${correlation.symbol2}`} 
+                           className="flex items-center justify-between p-3 bg-slate-50 rounded-lg">
+                        <div>
+                          <span className="font-medium text-slate-900">
+                            {correlation.symbol1} - {correlation.symbol2}
+                          </span>
+                          <p className="text-xs text-slate-500">
+                            {correlation.significance} significance
+                          </p>
+                        </div>
+                        <span className={`font-bold ${
+                          correlation.correlation > 0 ? 'text-error-600' : 'text-blue-600'
+                        }`}>
+                          {correlation.correlation.toFixed(3)}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </div>
+
+              <div className="card p-6">
+                <h4 className="text-lg font-semibold text-slate-900 mb-4">Diversification Opportunities</h4>
+                <div className="space-y-3">
+                  {data.correlations.data
+                    .filter(c => Math.abs(c.correlation) < 0.3)
+                    .sort((a, b) => Math.abs(a.correlation) - Math.abs(b.correlation))
+                    .slice(0, 5)
+                    .map((correlation) => (
+                      <div key={`${correlation.symbol1}-${correlation.symbol2}`} 
+                           className="flex items-center justify-between p-3 bg-success-50 rounded-lg">
+                        <div>
+                          <span className="font-medium text-slate-900">
+                            {correlation.symbol1} - {correlation.symbol2}
+                          </span>
+                          <p className="text-xs text-success-600">
+                            Good diversification pair
+                          </p>
+                        </div>
+                        <span className="font-bold text-success-600">
+                          {correlation.correlation.toFixed(3)}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Risk Summary Footer */}
+        <div className="card p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-6">
+              <div className="flex items-center space-x-2">
+                <div className={`w-3 h-3 rounded-full ${
+                  data?.metrics.riskLevel === 'low' ? 'bg-success-500' :
+                  data?.metrics.riskLevel === 'medium' ? 'bg-warning-500' :
+                  data?.metrics.riskLevel === 'high' ? 'bg-error-500' : 'bg-error-600'
+                } animate-pulse`}></div>
+                <span className="text-sm font-medium text-slate-900 capitalize">
+                  {data?.metrics.riskLevel || 'Unknown'} Risk Level
+                </span>
+              </div>
+              
+              <div className="text-sm text-slate-600">
+                Last updated: {new Date().toLocaleTimeString()}
+              </div>
+            </div>
+            
+            <div className="flex items-center space-x-4 text-sm">
+              <div>
+                <span className="text-slate-500">Portfolio VaR: </span>
+                <span className="font-semibold text-error-600">
+                  {data?.metrics.portfolioVaR.toFixed(2)}%
+                </span>
+              </div>
+              <div>
+                <span className="text-slate-500">Risk Score: </span>
+                <span className="font-semibold text-slate-900">
+                  {data?.metrics.riskScore}/100
+                </span>
+              </div>
+              <div>
+                <span className="text-slate-500">Active Alerts: </span>
+                <span className={`font-semibold ${
+                  criticalAlertsCount > 0 ? 'text-error-600' : 'text-success-600'
+                }`}>
+                  {criticalAlertsCount}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add interactive exposure chart with bar/pie views and category details
- implement advanced risk alerts with filtering, actions, and modal
- build correlation matrix with timeframe selector and correlation insights
- revamp risk dashboard page with tabbed navigation and auto-refresh

## Testing
- `npm run lint` *(fails: Unexpected any in api.ts and ws.ts)*
- `npx vitest run` *(fails: document is not defined in multiple tests)*
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b65c5cc064833198a51dab118c0964