### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import RiskDashboard from './pages/RiskDashboard';
 import Analytics from './pages/Analytics';
 import ExitRulesManager from './components/ExitRulesManager';
 import Layout from './components/layout/Layout';
-import { Page } from './components/layout/Sidebar';
+import type { Page } from './components/layout/Sidebar';
 
 const AuthenticatedApp: React.FC = () => {
   const [currentPage, setCurrentPage] = useState<Page>('dashboard');

--- a/frontend/src/components/dashboard/MetricCard.tsx
+++ b/frontend/src/components/dashboard/MetricCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface MetricCardProps {
   title: string;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import Sidebar, { Page } from './Sidebar';
+import Sidebar, { type Page } from './Sidebar';
 import Header from './Header';
 
 interface LayoutProps {

--- a/frontend/src/components/risk/RiskAlerts.tsx
+++ b/frontend/src/components/risk/RiskAlerts.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-  AlertTriangle, Shield, Clock, CheckCircle, XCircle,
+  AlertTriangle, Shield, CheckCircle, XCircle,
   Bell, Settings, X, Eye, EyeOff, Activity, TrendingUp,
   BarChart3, Target, Globe
 } from 'lucide-react';

--- a/frontend/src/components/trades/PnLChart.tsx
+++ b/frontend/src/components/trades/PnLChart.tsx
@@ -272,8 +272,9 @@ const PnLChart: React.FC<PnLChartProps> = ({
                   r="4"
                   fill={isPositive ? '#22c55e' : '#ef4444'}
                   className="opacity-0 hover:opacity-100 transition-opacity duration-200 cursor-pointer"
-                  title={`${point.date}: $${value.toFixed(2)}`}
-                />
+                >
+                  <title>{`${point.date}: $${value.toFixed(2)}`}</title>
+                </circle>
               );
             })}
           </svg>

--- a/frontend/src/pages/RiskDashboard.tsx
+++ b/frontend/src/pages/RiskDashboard.tsx
@@ -191,13 +191,13 @@ const RiskDashboard: React.FC = () => {
     fetchRiskData();
     
     // Auto-refresh every 2 minutes if enabled
-    let interval: NodeJS.Timeout | null = null;
+    let interval: number | null = null;
     if (autoRefresh) {
-      interval = setInterval(fetchRiskData, 120000);
+      interval = window.setInterval(fetchRiskData, 120000);
     }
-    
+
     return () => {
-      if (interval) clearInterval(interval);
+      if (interval !== null) window.clearInterval(interval);
     };
   }, [autoRefresh]);
 


### PR DESCRIPTION
## Summary
- use type-only imports for shared types to satisfy `verbatimModuleSyntax`
- remove unused `Clock` import in risk alerts component
- switch chart tooltip implementation to nested `<title>` element
- replace Node.js timeout types with browser-friendly `window.setInterval`

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b65e1e09c88331b96b2ae91e1c780b