### PR TITLE
chore: add env typing and broker debug helper

### DIFF
--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_USE_LIVE_BROKER: string;    // "true" | "false"
+  readonly VITE_LOG_BROKER_WIRE: string;    // "true" | "false"
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/src/services/LiveBrokerDataSource.ts
+++ b/frontend/src/services/LiveBrokerDataSource.ts
@@ -1,0 +1,13 @@
+export default class LiveBrokerDataSource {
+  private log = import.meta.env.VITE_LOG_BROKER_WIRE === 'true';
+  private useLive = import.meta.env.VITE_USE_LIVE_BROKER === 'true';
+
+  private dbg(...args: any[]) {
+    if (this.log) console.debug('[broker]', ...args);
+  }
+
+  handleAccountUpdate(mapped: any) {
+    // Previously: console.debug('broker:account', mapped)
+    this.dbg('account', mapped);
+  }
+}


### PR DESCRIPTION
## Summary
- define Vite environment variable types
- add broker data source debug helper and use it for account logs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 67 problems (62 errors, 5 warnings))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.execution.bracket_order_integration_test')*

------
https://chatgpt.com/codex/tasks/task_e_68b709422f248331985f1e186f042361