### PR TITLE
Connect signals page to backend data

### DIFF
--- a/frontend/src/components/signals/SignalCard.tsx
+++ b/frontend/src/components/signals/SignalCard.tsx
@@ -1,43 +1,55 @@
 import React from 'react';
 import {
-  TrendingUp, TrendingDown, Clock, CheckCircle, XCircle,
-  Brain, Target, MoreVertical, Play, X, Eye
+  TrendingUp,
+  TrendingDown,
+  Clock,
+  CheckCircle,
+  XCircle,
+  MoreVertical,
+  X,
+  Eye,
+  Target,
 } from 'lucide-react';
 import SymbolLogo from '../SymbolLogo';
+
+export type SignalStatus =
+  | 'pending'
+  | 'validated'
+  | 'rejected'
+  | 'executed'
+  | 'bracket_created'
+  | 'bracket_failed'
+  | 'error';
 
 interface Signal {
   id: number;
   symbol: string;
-  action: 'BUY' | 'SELL';
-  price: number;
-  confidence: number;
+  action: 'buy' | 'sell';
   strategy_id: string;
-  strategy_name?: string;
-  created_at: string;
-  status: 'pending' | 'processed' | 'error' | 'cancelled';
+  status: SignalStatus;
+  timestamp: string;
   quantity?: number;
-  target_price?: number;
-  stop_loss?: number;
-  reasoning?: string;
-  market_conditions?: string;
+  confidence?: number;
+  reason?: string;
+  error_message?: string;
 }
 
 interface SignalCardProps {
   signal: Signal;
-  onExecute?: (signalId: number) => void;
-  onCancel?: (signalId: number) => void;
+  onApprove?: (signalId: number) => void;
+  onReject?: (signalId: number) => void;
   onViewDetails?: (signal: Signal) => void;
   compact?: boolean;
 }
 
 const SignalCard: React.FC<SignalCardProps> = ({
   signal,
-  onExecute,
-  onCancel,
+  onApprove,
+  onReject,
   onViewDetails,
-  compact = false
+  compact = false,
 }) => {
-  const getStatusConfig = (status: Signal['status']) => {
+  const getStatusConfig = (status: SignalStatus) => {
     switch (status) {
       case 'pending':
         return {
@@ -46,16 +58,43 @@ const SignalCard: React.FC<SignalCardProps> = ({
           bg: 'bg-warning-50',
           border: 'border-warning-200',
           label: 'Pending',
-          pulse: true
+          pulse: true,
         };
-      case 'processed':
+      case 'validated':
+        return {
+          icon: CheckCircle,
+          color: 'text-blue-600',
+          bg: 'bg-blue-50',
+          border: 'border-blue-200',
+          label: 'Validated',
+          pulse: false,
+        };
+      case 'executed':
         return {
           icon: CheckCircle,
           color: 'text-success-600',
           bg: 'bg-success-50',
           border: 'border-success-200',
           label: 'Executed',
-          pulse: false
+          pulse: false,
+        };
+      case 'bracket_created':
+        return {
+          icon: CheckCircle,
+          color: 'text-indigo-600',
+          bg: 'bg-indigo-50',
+          border: 'border-indigo-200',
+          label: 'Bracket Created',
+          pulse: false,
+        };
+      case 'bracket_failed':
+        return {
+          icon: XCircle,
+          color: 'text-error-600',
+          bg: 'bg-error-50',
+          border: 'border-error-200',
+          label: 'Bracket Failed',
+          pulse: false,
         };
       case 'error':
         return {
@@ -63,40 +102,50 @@ const SignalCard: React.FC<SignalCardProps> = ({
           color: 'text-error-600',
           bg: 'bg-error-50',
           border: 'border-error-200',
-          label: 'Failed',
-          pulse: false
+          label: 'Error',
+          pulse: false,
         };
-      case 'cancelled':
+      case 'rejected':
         return {
           icon: X,
           color: 'text-slate-500',
           bg: 'bg-slate-50',
           border: 'border-slate-200',
-          label: 'Cancelled',
-          pulse: false
+          label: 'Rejected',
+          pulse: false,
+        };
+      default:
+        return {
+          icon: Clock,
+          color: 'text-slate-600',
+          bg: 'bg-slate-50',
+          border: 'border-slate-200',
+          label: status,
+          pulse: false,
         };
     }
   };
 
-  const getActionConfig = (action: 'BUY' | 'SELL') => {
-    return action === 'BUY'
+  const getActionConfig = (action: 'buy' | 'sell') =>
+    action === 'buy'
       ? {
           color: 'text-success-700',
           bg: 'bg-success-100',
           border: 'border-success-200',
-          icon: TrendingUp
+          icon: TrendingUp,
         }
       : {
           color: 'text-error-700',
           bg: 'bg-error-100',
           border: 'border-error-200',
-          icon: TrendingDown
+          icon: TrendingDown,
         };
-  };
 
   const getConfidenceColor = (confidence: number) => {
-    if (confidence >= 80) return 'text-success-600 bg-success-100 border-success-200';
-    if (confidence >= 60) return 'text-warning-600 bg-warning-100 border-warning-200';
+    if (confidence >= 80)
+      return 'text-success-600 bg-success-100 border-success-200';
+    if (confidence >= 60)
+      return 'text-warning-600 bg-warning-100 border-warning-200';
     return 'text-error-600 bg-error-100 border-error-200';
   };
 
@@ -105,7 +154,7 @@ const SignalCard: React.FC<SignalCardProps> = ({
     const signalTime = new Date(dateString);
     const diffMs = now.getTime() - signalTime.getTime();
     const diffMinutes = Math.floor(diffMs / (1000 * 60));
-    
+
     if (diffMinutes < 1) return 'Just now';
     if (diffMinutes < 60) return `${diffMinutes}m ago`;
     if (diffMinutes < 1440) return `${Math.floor(diffMinutes / 60)}h ago`;
@@ -116,6 +165,7 @@ const SignalCard: React.FC<SignalCardProps> = ({
   const actionConfig = getActionConfig(signal.action);
   const StatusIcon = statusConfig.icon;
   const ActionIcon = actionConfig.icon;
+  const confidence = signal.confidence ?? 0;
 
   if (compact) {
     return (
@@ -126,23 +176,37 @@ const SignalCard: React.FC<SignalCardProps> = ({
             <SymbolLogo symbol={signal.symbol} className="w-8 h-8" />
             <div>
               <div className="flex items-center space-x-2">
-                <span className="font-semibold text-slate-900">{signal.symbol}</span>
-                <span className={`inline-flex items-center px-2 py-1 rounded-lg text-xs font-semibold border ${actionConfig.bg} ${actionConfig.color} ${actionConfig.border}`}>
+                <span className="font-semibold text-slate-900">
+                  {signal.symbol}
+                </span>
+                <span
+                  className={`inline-flex items-center px-2 py-1 rounded-lg text-xs font-semibold border ${actionConfig.bg} ${actionConfig.color} ${actionConfig.border}`}
+                >
                   <ActionIcon className="w-3 h-3 mr-1" />
-                  {signal.action}
+                  {signal.action.toUpperCase()}
                 </span>
               </div>
-              <p className="text-sm text-slate-600">${signal.price.toFixed(2)}</p>
+              <p className="text-sm text-slate-600">{signal.strategy_id}</p>
             </div>
           </div>
 
           {/* Status & Confidence */}
           <div className="flex items-center space-x-2 ml-auto">
-            <span className={`inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-semibold border ${getConfidenceColor(signal.confidence)}`}>
-              {signal.confidence}%
-            </span>
-            <div className={`p-2 rounded-lg ${statusConfig.bg} ${statusConfig.border} border`}>
-              <StatusIcon className={`w-4 h-4 ${statusConfig.color} ${statusConfig.pulse ? 'animate-pulse' : ''}`} />
+            {signal.confidence !== undefined && (
+              <span
+                className={`inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-semibold border ${getConfidenceColor(
+                  confidence,
+                )}`}
+              >
+                {confidence}%
+              </span>
+            )}
+            <div
+              className={`p-2 rounded-lg ${statusConfig.bg} ${statusConfig.border} border`}
+            >
+              <StatusIcon
+                className={`w-4 h-4 ${statusConfig.color} ${statusConfig.pulse ? 'animate-pulse' : ''}`}
+              />
             </div>
           </div>
         </div>
@@ -158,36 +222,35 @@ const SignalCard: React.FC<SignalCardProps> = ({
           <SymbolLogo symbol={signal.symbol} className="w-12 h-12" />
           <div>
             <div className="flex items-center space-x-3 mb-1">
-              <h3 className="text-lg font-bold text-slate-900">{signal.symbol}</h3>
-              <span className={`inline-flex items-center px-3 py-1.5 rounded-xl text-sm font-semibold border ${actionConfig.bg} ${actionConfig.color} ${actionConfig.border}`}>
+              <h3 className="text-lg font-bold text-slate-900">
+                {signal.symbol}
+              </h3>
+              <span
+                className={`inline-flex items-center px-3 py-1.5 rounded-xl text-sm font-semibold border ${actionConfig.bg} ${actionConfig.color} ${actionConfig.border}`}
+              >
                 <ActionIcon className="w-4 h-4 mr-2" />
-                {signal.action} Signal
+                {signal.action.toUpperCase()}
               </span>
             </div>
             <div className="flex items-center space-x-4 text-sm text-slate-600">
-              <span>${signal.price.toFixed(2)}</span>
-              {signal.strategy_name && (
-                <>
-                  <span>•</span>
-                  <span className="flex items-center">
-                    <Brain className="w-3 h-3 mr-1" />
-                    {signal.strategy_name}
-                  </span>
-                </>
-              )}
+              <span>Strategy: {signal.strategy_id}</span>
               <span>•</span>
-              <span>{formatTime(signal.created_at)}</span>
+              <span>{formatTime(signal.timestamp)}</span>
             </div>
           </div>
         </div>
 
-        {/* Status & Actions */}
+        {/* Status */}
         <div className="flex items-center space-x-3">
-          <span className={`inline-flex items-center px-3 py-1.5 rounded-xl text-sm font-semibold border ${statusConfig.bg} ${statusConfig.color} ${statusConfig.border}`}>
-            <StatusIcon className={`w-4 h-4 mr-2 ${statusConfig.pulse ? 'animate-pulse' : ''}`} />
+          <span
+            className={`inline-flex items-center px-3 py-1.5 rounded-xl text-sm font-semibold border ${statusConfig.bg} ${statusConfig.color} ${statusConfig.border}`}
+          >
+            <StatusIcon
+              className={`w-4 h-4 mr-2 ${statusConfig.pulse ? 'animate-pulse' : ''}`}
+            />
             {statusConfig.label}
           </span>
-          
+
           <div className="relative">
             <button className="p-2 rounded-xl hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors">
               <MoreVertical className="w-4 h-4" />
@@ -198,39 +261,53 @@ const SignalCard: React.FC<SignalCardProps> = ({
 
       {/* Metrics Grid */}
       <div className="grid grid-cols-3 gap-4 mb-4">
-        <div className="text-center p-3 bg-slate-50 rounded-xl">
-          <p className="text-xs font-medium text-slate-500 mb-1">Confidence</p>
-          <div className="flex items-center justify-center space-x-1">
-            <div className={`w-2 h-2 rounded-full ${getConfidenceColor(signal.confidence).includes('success') ? 'bg-success-500' : getConfidenceColor(signal.confidence).includes('warning') ? 'bg-warning-500' : 'bg-error-500'}`}></div>
-            <span className="text-lg font-bold text-slate-900">{signal.confidence}%</span>
-          </div>
-        </div>
-
-        {signal.target_price && (
+        {signal.confidence !== undefined && (
           <div className="text-center p-3 bg-slate-50 rounded-xl">
-            <p className="text-xs font-medium text-slate-500 mb-1">Target</p>
-            <p className="text-lg font-bold text-slate-900">${signal.target_price.toFixed(2)}</p>
+            <p className="text-xs font-medium text-slate-500 mb-1">
+              Confidence
+            </p>
+            <div className="flex items-center justify-center space-x-1">
+              <div
+                className={`w-2 h-2 rounded-full ${getConfidenceColor(confidence).includes('success')
+                  ? 'bg-success-500'
+                  : getConfidenceColor(confidence).includes('warning')
+                    ? 'bg-warning-500'
+                    : 'bg-error-500'
+                }`}
+              />
+              <span className="text-lg font-bold text-slate-900">
+                {confidence}%
+              </span>
+            </div>
           </div>
         )}
 
-        {signal.quantity && (
+        {signal.quantity !== undefined && (
           <div className="text-center p-3 bg-slate-50 rounded-xl">
             <p className="text-xs font-medium text-slate-500 mb-1">Quantity</p>
-            <p className="text-lg font-bold text-slate-900">{signal.quantity}</p>
+            <p className="text-lg font-bold text-slate-900">
+              {signal.quantity}
+            </p>
           </div>
         )}
       </div>
 
-      {/* Reasoning */}
-      {signal.reasoning && (
+      {/* Reason */}
+      {signal.reason && (
         <div className="mb-4">
           <h4 className="text-sm font-medium text-slate-700 mb-2 flex items-center">
             <Target className="w-4 h-4 mr-1" />
-            Signal Reasoning
+            Reason
           </h4>
           <p className="text-sm text-slate-600 bg-slate-50 p-3 rounded-xl">
-            {signal.reasoning}
+            {signal.reason}
           </p>
+        </div>
+      )}
+
+      {signal.error_message && (
+        <div className="mb-4 text-sm text-error-600 bg-error-50 border border-error-200 p-3 rounded-xl">
+          {signal.error_message}
         </div>
       )}
 
@@ -238,11 +315,11 @@ const SignalCard: React.FC<SignalCardProps> = ({
       {signal.status === 'pending' && (
         <div className="flex items-center space-x-3 pt-4 border-t border-slate-100">
           <button
-            onClick={() => onExecute?.(signal.id)}
+            onClick={() => onApprove?.(signal.id)}
             className="btn-primary flex-1"
           >
-            <Play className="w-4 h-4 mr-2" />
-            Execute Signal
+            <CheckCircle className="w-4 h-4 mr-2" />
+            Approve
           </button>
           <button
             onClick={() => onViewDetails?.(signal)}
@@ -252,11 +329,11 @@ const SignalCard: React.FC<SignalCardProps> = ({
             Details
           </button>
           <button
-            onClick={() => onCancel?.(signal.id)}
+            onClick={() => onReject?.(signal.id)}
             className="btn-ghost text-error-600 hover:bg-error-50"
           >
             <X className="w-4 h-4 mr-2" />
-            Cancel
+            Reject
           </button>
         </div>
       )}
@@ -277,3 +354,4 @@ const SignalCard: React.FC<SignalCardProps> = ({
 };
 
 export default SignalCard;
+

--- a/frontend/src/components/signals/SignalFilters.tsx
+++ b/frontend/src/components/signals/SignalFilters.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {
   Search, TrendingUp, TrendingDown,
-  Clock, CheckCircle, XCircle, X, SlidersHorizontal
+  Clock, CheckCircle, XCircle, X, SlidersHorizontal,
+  AlertCircle, Target
 } from 'lucide-react';
 
 interface FilterOptions {
@@ -28,14 +29,17 @@ const SignalFilters: React.FC<SignalFiltersProps> = ({
 }) => {
   const statusOptions = [
     { value: 'pending', label: 'Pending', icon: Clock, color: 'text-warning-600' },
-    { value: 'processed', label: 'Executed', icon: CheckCircle, color: 'text-success-600' },
-    { value: 'error', label: 'Failed', icon: XCircle, color: 'text-error-600' },
-    { value: 'cancelled', label: 'Cancelled', icon: X, color: 'text-slate-500' }
+    { value: 'validated', label: 'Validated', icon: CheckCircle, color: 'text-blue-600' },
+    { value: 'executed', label: 'Executed', icon: CheckCircle, color: 'text-success-600' },
+    { value: 'bracket_created', label: 'Bracket Created', icon: Target, color: 'text-indigo-600' },
+    { value: 'bracket_failed', label: 'Bracket Failed', icon: XCircle, color: 'text-error-600' },
+    { value: 'error', label: 'Error', icon: AlertCircle, color: 'text-error-600' },
+    { value: 'rejected', label: 'Rejected', icon: X, color: 'text-slate-500' },
   ];
 
   const actionOptions = [
-    { value: 'BUY', label: 'Buy', icon: TrendingUp, color: 'text-success-600' },
-    { value: 'SELL', label: 'Sell', icon: TrendingDown, color: 'text-error-600' }
+    { value: 'buy', label: 'Buy', icon: TrendingUp, color: 'text-success-600' },
+    { value: 'sell', label: 'Sell', icon: TrendingDown, color: 'text-error-600' },
   ];
 
   const dateRangeOptions = [
@@ -46,7 +50,7 @@ const SignalFilters: React.FC<SignalFiltersProps> = ({
     { value: 'custom', label: 'Custom range' }
   ];
 
-  const updateFilter = (key: keyof FilterOptions, value: any) => {
+  const updateFilter = <K extends keyof FilterOptions>(key: K, value: FilterOptions[K]) => {
     onFiltersChange({ ...filters, [key]: value });
   };
 

--- a/frontend/src/components/signals/SignalModal.tsx
+++ b/frontend/src/components/signals/SignalModal.tsx
@@ -1,72 +1,78 @@
 import React from 'react';
 import {
-  X, TrendingUp, TrendingDown, Brain, Target,
-  Clock, Zap, BarChart3, AlertTriangle
+  X,
+  TrendingUp,
+  TrendingDown,
+  CheckCircle,
+  XCircle,
 } from 'lucide-react';
+
+import { SignalStatus } from './SignalCard';
 
 interface Signal {
   id: number;
   symbol: string;
-  action: 'BUY' | 'SELL';
-  price: number;
-  confidence: number;
+  action: 'buy' | 'sell';
   strategy_id: string;
-  strategy_name?: string;
-  created_at: string;
-  status: 'pending' | 'processed' | 'error' | 'cancelled';
+  status: SignalStatus;
+  timestamp: string;
   quantity?: number;
-  target_price?: number;
-  stop_loss?: number;
-  reasoning?: string;
-  market_conditions?: string;
-  risk_score?: number;
-  expected_return?: number;
+  confidence?: number;
+  reason?: string;
+  error_message?: string;
 }
 
 interface SignalModalProps {
   signal: Signal | null;
   isOpen: boolean;
   onClose: () => void;
-  onExecute?: (signalId: number) => void;
-  onCancel?: (signalId: number) => void;
+  onApprove?: (signalId: number) => void;
+  onReject?: (signalId: number) => void;
 }
+
+const statusLabels: Record<SignalStatus, string> = {
+  pending: 'Pending',
+  validated: 'Validated',
+  rejected: 'Rejected',
+  executed: 'Executed',
+  bracket_created: 'Bracket Created',
+  bracket_failed: 'Bracket Failed',
+  error: 'Error',
+};
 
 const SignalModal: React.FC<SignalModalProps> = ({
   signal,
   isOpen,
   onClose,
-  onExecute,
-  onCancel
+  onApprove,
+  onReject,
 }) => {
   if (!isOpen || !signal) return null;
 
-  const ActionIcon = signal.action === 'BUY' ? TrendingUp : TrendingDown;
-  const actionColor = signal.action === 'BUY' ? 'text-success-600' : 'text-error-600';
-  const actionBg = signal.action === 'BUY' ? 'bg-success-50' : 'bg-error-50';
+  const ActionIcon = signal.action === 'buy' ? TrendingUp : TrendingDown;
+  const actionColor = signal.action === 'buy' ? 'text-success-600' : 'text-error-600';
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-        {/* Background overlay */}
         <div
           className="fixed inset-0 transition-opacity bg-slate-500 bg-opacity-75 backdrop-blur-sm"
           onClick={onClose}
         />
 
-        {/* Modal */}
-        <div className="inline-block w-full max-w-2xl my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-strong rounded-2xl">
+        <div className="inline-block w-full max-w-lg my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-strong rounded-2xl">
           {/* Header */}
           <div className="flex items-center justify-between p-6 border-b border-slate-200">
             <div className="flex items-center space-x-4">
-              <div className={`p-3 rounded-xl ${actionBg}`}>
+              <div className={`p-3 rounded-xl ${signal.action === 'buy' ? 'bg-success-50' : 'bg-error-50'}`}>
                 <ActionIcon className={`w-6 h-6 ${actionColor}`} />
               </div>
               <div>
                 <h3 className="text-xl font-bold text-slate-900">
-                  {signal.action} {signal.symbol}
+                  {signal.action.toUpperCase()} {signal.symbol}
                 </h3>
                 <p className="text-sm text-slate-600">
-                  Signal #{signal.id} • {new Date(signal.created_at).toLocaleString()}
+                  Signal #{signal.id} • {new Date(signal.timestamp).toLocaleString()}
                 </p>
               </div>
             </div>
@@ -79,174 +85,71 @@ const SignalModal: React.FC<SignalModalProps> = ({
           </div>
 
           {/* Content */}
-          <div className="p-6 space-y-6">
-            {/* Key Metrics */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className="text-center p-4 bg-slate-50 rounded-xl">
-                <p className="text-xs font-medium text-slate-500 mb-1">Price</p>
-                <p className="text-lg font-bold text-slate-900">${signal.price.toFixed(2)}</p>
+          <div className="p-6 space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-xs font-medium text-slate-500 mb-1">Status</p>
+                <p className="text-sm font-semibold text-slate-900">
+                  {statusLabels[signal.status]}
+                </p>
               </div>
-              <div className="text-center p-4 bg-slate-50 rounded-xl">
-                <p className="text-xs font-medium text-slate-500 mb-1">Confidence</p>
-                <p className="text-lg font-bold text-primary-600">{signal.confidence}%</p>
-              </div>
-              {signal.target_price && (
-                <div className="text-center p-4 bg-slate-50 rounded-xl">
-                  <p className="text-xs font-medium text-slate-500 mb-1">Target</p>
-                  <p className="text-lg font-bold text-success-600">${signal.target_price.toFixed(2)}</p>
+              {signal.confidence !== undefined && (
+                <div>
+                  <p className="text-xs font-medium text-slate-500 mb-1">Confidence</p>
+                  <p className="text-sm font-semibold text-slate-900">
+                    {signal.confidence}%
+                  </p>
                 </div>
               )}
-              {signal.stop_loss && (
-                <div className="text-center p-4 bg-slate-50 rounded-xl">
-                  <p className="text-xs font-medium text-slate-500 mb-1">Stop Loss</p>
-                  <p className="text-lg font-bold text-error-600">${signal.stop_loss.toFixed(2)}</p>
+              {signal.quantity !== undefined && (
+                <div>
+                  <p className="text-xs font-medium text-slate-500 mb-1">Quantity</p>
+                  <p className="text-sm font-semibold text-slate-900">
+                    {signal.quantity}
+                  </p>
                 </div>
               )}
+              <div>
+                <p className="text-xs font-medium text-slate-500 mb-1">Strategy</p>
+                <p className="text-sm font-semibold text-slate-900">
+                  {signal.strategy_id}
+                </p>
+              </div>
             </div>
 
-            {/* Strategy Information */}
-            {signal.strategy_name && (
-              <div className="p-4 bg-primary-50 rounded-xl border border-primary-100">
-                <h4 className="flex items-center text-sm font-semibold text-primary-900 mb-2">
-                  <Brain className="w-4 h-4 mr-2" />
-                  Strategy: {signal.strategy_name}
-                </h4>
-                <p className="text-sm text-primary-700">
-                  Strategy ID: {signal.strategy_id}
+            {signal.reason && (
+              <div>
+                <p className="text-xs font-medium text-slate-500 mb-1">Reason</p>
+                <p className="text-sm text-slate-700 bg-slate-50 p-3 rounded-xl">
+                  {signal.reason}
                 </p>
               </div>
             )}
 
-            {/* Signal Reasoning */}
-            {signal.reasoning && (
-              <div>
-                <h4 className="flex items-center text-sm font-semibold text-slate-900 mb-3">
-                  <Target className="w-4 h-4 mr-2 text-primary-600" />
-                  Signal Analysis
-                </h4>
-                <div className="p-4 bg-slate-50 rounded-xl">
-                  <p className="text-sm text-slate-700 leading-relaxed">
-                    {signal.reasoning}
-                  </p>
-                </div>
-              </div>
-            )}
-
-            {/* Market Conditions */}
-            {signal.market_conditions && (
-              <div>
-                <h4 className="flex items-center text-sm font-semibold text-slate-900 mb-3">
-                  <BarChart3 className="w-4 h-4 mr-2 text-primary-600" />
-                  Market Conditions
-                </h4>
-                <div className="p-4 bg-slate-50 rounded-xl">
-                  <p className="text-sm text-slate-700 leading-relaxed">
-                    {signal.market_conditions}
-                  </p>
-                </div>
-              </div>
-            )}
-
-            {/* Risk Assessment */}
-            {(signal.risk_score || signal.expected_return) && (
-              <div>
-                <h4 className="flex items-center text-sm font-semibold text-slate-900 mb-3">
-                  <AlertTriangle className="w-4 h-4 mr-2 text-warning-600" />
-                  Risk Assessment
-                </h4>
-                <div className="grid grid-cols-2 gap-4">
-                  {signal.risk_score && (
-                    <div className="p-4 bg-warning-50 rounded-xl border border-warning-100">
-                      <p className="text-xs font-medium text-warning-600 mb-1">Risk Score</p>
-                      <p className="text-lg font-bold text-warning-700">{signal.risk_score}/10</p>
-                    </div>
-                  )}
-                  {signal.expected_return && (
-                    <div className="p-4 bg-success-50 rounded-xl border border-success-100">
-                      <p className="text-xs font-medium text-success-600 mb-1">Expected Return</p>
-                      <p className="text-lg font-bold text-success-700">+{signal.expected_return.toFixed(1)}%</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* Trade Details */}
-            {signal.quantity && (
-              <div>
-                <h4 className="flex items-center text-sm font-semibold text-slate-900 mb-3">
-                  <Zap className="w-4 h-4 mr-2 text-primary-600" />
-                  Trade Details
-                </h4>
-                <div className="p-4 bg-slate-50 rounded-xl">
-                  <div className="grid grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <span className="text-slate-500">Quantity:</span>
-                      <span className="ml-2 font-semibold text-slate-900">{signal.quantity} shares</span>
-                    </div>
-                    <div>
-                      <span className="text-slate-500">Total Value:</span>
-                      <span className="ml-2 font-semibold text-slate-900">
-                        ${(signal.quantity * signal.price).toLocaleString()}
-                      </span>
-                    </div>
-                    {signal.target_price && (
-                      <div>
-                        <span className="text-slate-500">Potential Profit:</span>
-                        <span className="ml-2 font-semibold text-success-600">
-                          +${((signal.target_price - signal.price) * signal.quantity).toLocaleString()}
-                        </span>
-                      </div>
-                    )}
-                    {signal.stop_loss && (
-                      <div>
-                        <span className="text-slate-500">Max Loss:</span>
-                        <span className="ml-2 font-semibold text-error-600">
-                          -${((signal.price - signal.stop_loss) * signal.quantity).toLocaleString()}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
+            {signal.error_message && (
+              <div className="text-sm text-error-600 bg-error-50 border border-error-200 p-3 rounded-xl">
+                {signal.error_message}
               </div>
             )}
           </div>
 
-          {/* Footer Actions */}
-          <div className="flex items-center justify-between p-6 bg-slate-50 border-t border-slate-200">
-            <div className="flex items-center space-x-2 text-sm text-slate-600">
-              <Clock className="w-4 h-4" />
-              <span>Created {new Date(signal.created_at).toLocaleString()}</span>
+          {/* Actions */}
+          {signal.status === 'pending' && (
+            <div className="flex items-center space-x-3 p-6 pt-0">
+              <button
+                onClick={() => onApprove?.(signal.id)}
+                className="btn-primary flex-1"
+              >
+                <CheckCircle className="w-4 h-4 mr-2" /> Approve
+              </button>
+              <button
+                onClick={() => onReject?.(signal.id)}
+                className="btn-ghost text-error-600 hover:bg-error-50"
+              >
+                <XCircle className="w-4 h-4 mr-2" /> Reject
+              </button>
             </div>
-            
-            <div className="flex items-center space-x-3">
-              {signal.status === 'pending' && (
-                <>
-                  <button
-                    onClick={() => onCancel?.(signal.id)}
-                    className="btn-ghost text-error-600 hover:bg-error-50"
-                  >
-                    Cancel Signal
-                  </button>
-                  <button
-                    onClick={() => {
-                      onExecute?.(signal.id);
-                      onClose();
-                    }}
-                    className="btn-primary"
-                  >
-                    <Zap className="w-4 h-4 mr-2" />
-                    Execute Now
-                  </button>
-                </>
-              )}
-              {signal.status !== 'pending' && (
-                <button onClick={onClose} className="btn-secondary">
-                  Close
-                </button>
-              )}
-            </div>
-          </div>
+          )}
         </div>
       </div>
     </div>
@@ -254,3 +157,4 @@ const SignalModal: React.FC<SignalModalProps> = ({
 };
 
 export default SignalModal;
+


### PR DESCRIPTION
## Summary
- Load trading signals from `/api/v1/signals` and display real statuses with auto refresh
- Add approve/reject actions and strategy/status filters
- Provide updated signal cards and modal for new backend fields

## Testing
- `npm run lint` *(fails: Unexpected any and related errors in existing files)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b76db9fcb08331a8bb9bbf3e3d0172