### PR TITLE
feat: connect orders page to broker API

### DIFF
--- a/frontend/src/components/orders/OrderFilters.tsx
+++ b/frontend/src/components/orders/OrderFilters.tsx
@@ -30,10 +30,13 @@ const OrderFilters: React.FC<OrderFiltersProps> = ({
   onReset
 }) => {
   const statusOptions = [
-    { value: 'pending', label: 'Pending', icon: Clock, color: 'text-warning-600' },
-    { value: 'filled', label: 'Filled', icon: CheckCircle, color: 'text-success-600' },
+    { value: 'new', label: 'New', icon: Clock, color: 'text-warning-600' },
+    { value: 'sent', label: 'Sent', icon: Clock, color: 'text-warning-600' },
+    { value: 'accepted', label: 'Accepted', icon: Clock, color: 'text-warning-600' },
     { value: 'partially_filled', label: 'Partial', icon: Activity, color: 'text-primary-600' },
-    { value: 'cancelled', label: 'Cancelled', icon: X, color: 'text-slate-500' },
+    { value: 'filled', label: 'Filled', icon: CheckCircle, color: 'text-success-600' },
+    { value: 'pending_cancel', label: 'Pending Cancel', icon: Clock, color: 'text-warning-600' },
+    { value: 'canceled', label: 'Canceled', icon: X, color: 'text-slate-500' },
     { value: 'rejected', label: 'Rejected', icon: XCircle, color: 'text-error-600' }
   ];
 
@@ -46,7 +49,8 @@ const OrderFilters: React.FC<OrderFiltersProps> = ({
     { value: 'market', label: 'Market', color: 'text-primary-600' },
     { value: 'limit', label: 'Limit', color: 'text-indigo-600' },
     { value: 'stop', label: 'Stop', color: 'text-warning-600' },
-    { value: 'stop_limit', label: 'Stop Limit', color: 'text-error-600' }
+    { value: 'stop_limit', label: 'Stop Limit', color: 'text-error-600' },
+    { value: 'bracket', label: 'Bracket', color: 'text-purple-600' }
   ];
 
   const dateRangeOptions = [

--- a/frontend/src/components/orders/OrderTimeline.tsx
+++ b/frontend/src/components/orders/OrderTimeline.tsx
@@ -6,7 +6,7 @@ import {
 
 interface TimelineEvent {
   id: string;
-  type: 'created' | 'submitted' | 'partially_filled' | 'filled' | 'cancelled' | 'rejected' | 'modified';
+  type: 'created' | 'submitted' | 'partially_filled' | 'filled' | 'canceled' | 'rejected' | 'modified';
   timestamp: string;
   description: string;
   details?: string;
@@ -30,7 +30,7 @@ const OrderTimeline: React.FC<OrderTimelineProps> = ({ events, loading = false }
         return { icon: Activity, color: 'text-indigo-600', bg: 'bg-indigo-100', border: 'border-indigo-200' };
       case 'filled':
         return { icon: CheckCircle, color: 'text-success-600', bg: 'bg-success-100', border: 'border-success-200' };
-      case 'cancelled':
+      case 'canceled':
         return { icon: XCircle, color: 'text-slate-500', bg: 'bg-slate-100', border: 'border-slate-200' };
       case 'rejected':
         return { icon: XCircle, color: 'text-error-600', bg: 'bg-error-100', border: 'border-error-200' };

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -116,7 +116,7 @@ const Dashboard: React.FC = () => {
                 ? 'success'
                 : sig.status === 'error'
                 ? 'error'
-                : sig.status === 'cancelled'
+                : sig.status === 'canceled'
                 ? 'warning'
                 : 'pending',
             quantity: sig.quantity,
@@ -136,7 +136,7 @@ const Dashboard: React.FC = () => {
                 ? 'success'
                 : ord.status === 'rejected'
                 ? 'error'
-                : ord.status === 'canceled' || ord.status === 'cancelled'
+                : ord.status === 'canceled'
                 ? 'warning'
                 : 'pending',
             quantity: parseFloat(ord.filled_qty || ord.qty),


### PR DESCRIPTION
## Summary
- hook orders page into Alpaca-backed `/api/v1/orders` endpoint with real status parsing and cancel support
- extend order cards and filters to handle new broker states and bracket orders
- normalize status names across UI components

## Testing
- `npm run lint` (fails: Unexpected any. Specify a different type)
- `pytest` (errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68b76fc02dcc8331b170929e2c161417