### PR TITLE
fix: use type-only import for SignalStatus

### DIFF
--- a/frontend/src/components/signals/SignalModal.tsx
+++ b/frontend/src/components/signals/SignalModal.tsx
@@ -7,7 +7,7 @@ import {
   XCircle,
 } from 'lucide-react';
 
-import { SignalStatus } from './SignalCard';
+import type { SignalStatus } from './SignalCard';
 
 interface Signal {
   id: number;


### PR DESCRIPTION
## Summary
- import `SignalStatus` as a type in `SignalModal` to satisfy TS verbatimModuleSyntax

## Testing
- `npm run lint` *(fails: 73 problems (67 errors, 6 warnings))*
- `npm run build`
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b776af5554833199b40f17988dbf47