### PR TITLE
Fix account day change metrics and expose position PnL fields

### DIFF
--- a/app/api/v1/orders.py
+++ b/app/api/v1/orders.py
@@ -92,10 +92,20 @@ async def get_account(
     try:
         account = broker_client.get_account()
 
+        portfolio_value = float(getattr(account, "portfolio_value", 0))
+        cash = float(getattr(account, "cash", 0))
+        buying_power = float(getattr(account, "buying_power", 0))
+        prev_close = float(getattr(account, "last_equity", portfolio_value))
+        day_change = portfolio_value - prev_close
+        day_change_percent = (day_change / prev_close * 100) if prev_close else 0
+
         return {
-            "buying_power": str(getattr(account, "buying_power", 0)),
-            "cash": str(getattr(account, "cash", 0)),
-            "portfolio_value": str(getattr(account, "portfolio_value", 0)),
+            "buying_power": buying_power,
+            "cash": cash,
+            "portfolio_value": portfolio_value,
+            "day_change": day_change,
+            "day_change_percent": day_change_percent,
+            "prev_close": prev_close,
             "status": str(getattr(account, "status", "N/A")),
             "trading_blocked": getattr(account, "trading_blocked", False),
             "crypto_status": str(getattr(account, "crypto_trading_enabled", False)),

--- a/app/services/position_manager.py
+++ b/app/services/position_manager.py
@@ -49,12 +49,12 @@ class PositionManager:
                     detailed_positions.append({
                         'symbol': pos.symbol,
                         'quantity': float(pos.qty),
-                        'market_value': getattr(pos, 'market_value', 0.0),
-                        'unrealized_pl': getattr(pos, 'unrealized_pl', 0.0),  # SOLO PnL TOTAL
-                        'unrealized_plpc': getattr(pos, 'unrealized_plpc', 0.0),
-                        'cost_basis': getattr(pos, 'cost_basis', 0.0),
-                        'avg_entry_price': getattr(pos, 'avg_entry_price', 0.0),
-                        'current_price': getattr(pos, 'current_price', 0.0)
+                        'market_value': float(getattr(pos, 'market_value', 0) or 0.0),
+                        'unrealized_pl': float(getattr(pos, 'unrealized_pl', 0) or 0.0),  # SOLO PnL TOTAL
+                        'unrealized_plpc': float(getattr(pos, 'unrealized_plpc', 0) or 0.0),
+                        'cost_basis': float(getattr(pos, 'cost_basis', 0) or 0.0),
+                        'avg_entry_price': float(getattr(pos, 'avg_entry_price', 0) or 0.0),
+                        'current_price': float(getattr(pos, 'current_price', 0) or 0.0)
                     })
             return detailed_positions
         except Exception as e:
@@ -168,20 +168,22 @@ class PositionManager:
     def get_portfolio_summary(self, limit: int | None = None):
         """Resumen del portafolio"""
         try:
-            positions = self.get_current_positions()
+            detailed_positions = self.get_detailed_positions()
             account = self.broker.get_account()
 
             if limit is None:
                 limit = self.default_limit
 
+            total_positions = len(detailed_positions)
+
             return {
-                "total_positions": len(positions),
+                "total_positions": total_positions,
                 "max_positions": limit,
-                "remaining_slots": max(0, limit - len(positions)),
+                "remaining_slots": max(0, limit - total_positions),
                 "cash": float(account.cash),
                 "portfolio_value": float(account.portfolio_value),
                 "buying_power": float(account.buying_power),
-                "positions": positions
+                "positions": detailed_positions
             }
         except Exception as e:
             logger.error(f"Error getting portfolio summary: {e}")


### PR DESCRIPTION
## Summary
- include day change, percent and previous close in account endpoint
- return detailed positions with market value and PnL data

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.execution.bracket_order_integration_test')*

------
https://chatgpt.com/codex/tasks/task_e_68b7921fe1ac83319d21502e49812670