### PR TITLE
Fix Alpaca timeframe constants in portfolio performance endpoint

### DIFF
--- a/app/api/v1/portfolio_performance.py
+++ b/app/api/v1/portfolio_performance.py
@@ -45,16 +45,16 @@ async def get_portfolio_performance(
             timeframe_alpaca = "15Min"
         elif timeframe == TimeframeEnum.ONE_MONTH:
             start_date = end_date - timedelta(days=30)
-            timeframe_alpaca = "1Hour"
+            timeframe_alpaca = "1H"
         elif timeframe == TimeframeEnum.THREE_MONTHS:
             start_date = end_date - timedelta(days=90)
-            timeframe_alpaca = "1Day"
+            timeframe_alpaca = "1D"
         elif timeframe == TimeframeEnum.ONE_YEAR:
             start_date = end_date - timedelta(days=365)
-            timeframe_alpaca = "1Day"
+            timeframe_alpaca = "1D"
         else:  # ALL
-            start_date = end_date - timedelta(days=730)
-            timeframe_alpaca = "1Day"
+            start_date = end_date - timedelta(days=730)  # 2 years maximum
+            timeframe_alpaca = "1D"
 
         from alpaca.trading.requests import GetPortfolioHistoryRequest
 


### PR DESCRIPTION
## Summary
- Correct Alpaca timeframe strings for month, multi-month, yearly, and all-time requests in portfolio performance endpoint
- Clarify comment for historical data limit (2 years)

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.execution.bracket_order_integration_test')*

------
https://chatgpt.com/codex/tasks/task_e_68b79d985ff8833184bbe29c839ee6c7