### PR TITLE
fix: prevent dashboard flicker during auto refresh

### DIFF
--- a/frontend/src/components/dashboard/AlpacaStyleChart.tsx
+++ b/frontend/src/components/dashboard/AlpacaStyleChart.tsx
@@ -48,9 +48,12 @@ const AlpacaStyleChart: React.FC<AlpacaStyleChartProps> = ({
   ];
 
   const fetchData = async (
-    timeframe: '1D' | '1W' | '1M' | '3M' | '1Y' | 'ALL'
+    timeframe: '1D' | '1W' | '1M' | '3M' | '1Y' | 'ALL',
+    showLoading = true
   ) => {
-    setIsLoading(true);
+    if (showLoading) {
+      setIsLoading(true);
+    }
     setError(null);
 
     try {
@@ -77,7 +80,7 @@ const AlpacaStyleChart: React.FC<AlpacaStyleChartProps> = ({
   useEffect(() => {
     if (selectedTimeframe === '1D') {
       const interval = setInterval(() => {
-        fetchData('1D');
+        fetchData('1D', false); // No mostrar loading en actualizaciones automáticas
       }, 30000);
       return () => clearInterval(interval);
     }

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -49,9 +49,11 @@ const Dashboard: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchDashboardData = async () => {
+  const fetchDashboardData = async (isInitialLoad = false) => {
     try {
-      setLoading(true);
+      if (isInitialLoad) {
+        setLoading(true);
+      }
       setError(null);
 
       const [accountRes, positionsRes, signalsRes, ordersRes] = await Promise.all([
@@ -152,8 +154,8 @@ const Dashboard: React.FC = () => {
   };
 
   useEffect(() => {
-    fetchDashboardData();
-    const interval = setInterval(fetchDashboardData, 30000);
+    fetchDashboardData(true); // Solo mostrar loading en carga inicial
+    const interval = setInterval(() => fetchDashboardData(false), 30000); // Sin loading en actualizaciones
     return () => clearInterval(interval);
   }, []);
 
@@ -229,7 +231,7 @@ const Dashboard: React.FC = () => {
               {showValues ? 'Hide' : 'Show'} Values
             </button>
             <button
-              onClick={fetchDashboardData}
+              onClick={() => fetchDashboardData(true)} // Mostrar loading cuando el usuario hace refresh manual
               className="btn-secondary"
             >
               <RefreshCw className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- avoid toggling full-screen loading state on periodic dashboard refresh
- allow manual refresh to trigger loading indicator
- stop chart from showing loading spinner during automatic updates

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `npm run lint` (fails: Unexpected any in existing files)
- ⚠️ `pytest` (fails: 4 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68b8b50b547c8331a50835b60080b55c