### PR TITLE
feat: support abort signals in analytics API

### DIFF
--- a/frontend/src/components/analytics/PortfolioAnalytics.tsx
+++ b/frontend/src/components/analytics/PortfolioAnalytics.tsx
@@ -89,14 +89,18 @@ const PortfolioAnalytics: React.FC = () => {
         setLoading(true);
         setError(null);
 
-        const [metricsResponse, summaryResponse] = await Promise.all([
-          api.analytics.getPerformanceMetrics(selectedTimeframe, undefined, controller.signal),
-          api.analytics.getSummary(controller.signal)
+        const [metricsData, summaryData] = await Promise.all([
+          api.analytics.getPerformanceMetrics(
+            selectedTimeframe,
+            undefined,
+            controller.signal
+          ),
+          api.analytics.getSummary(undefined, controller.signal)
         ]);
 
         if (!isMounted) return;
-        setMetrics(metricsResponse);
-        setSummary(summaryResponse);
+        setMetrics(metricsData);
+        setSummary(summaryData);
       } catch (err) {
         if (!isMounted) return;
         console.error('Error fetching analytics:', err);

--- a/frontend/src/components/analytics/TradeDistribution.tsx
+++ b/frontend/src/components/analytics/TradeDistribution.tsx
@@ -55,9 +55,13 @@ const TradeDistribution: React.FC<TradeDistributionProps> = ({
         setLoading(true);
         setError(null);
 
-        const response = await api.analytics.getTradeAnalytics(timeframe, portfolioId, controller.signal);
+        const data = await api.analytics.getTradeAnalytics(
+          timeframe,
+          portfolioId,
+          controller.signal
+        );
         if (!isMounted) return;
-        setDistribution(response.trade_distribution);
+        setDistribution(data.trade_distribution);
       } catch (err) {
         if (!isMounted) return;
         console.error('Error fetching trade distribution:', err);

--- a/frontend/src/pages/trades/index.tsx
+++ b/frontend/src/pages/trades/index.tsx
@@ -153,28 +153,25 @@ const TradesPage: React.FC = () => {
 
   const fetchRealMetrics = async () => {
     try {
-      const response = await api.analytics.getPerformanceMetrics('1M');
-      if (response.ok) {
-        const data = await response.json();
-        setStats({
-          totalPnL: data.total_pnl,
-          totalTrades: data.total_trades,
-          winningTrades: data.winning_trades,
-          losingTrades: data.losing_trades,
-          winRate: data.win_rate,
-          avgWin: data.avg_win,
-          avgLoss: data.avg_loss,
-          bestTrade: data.largest_win,
-          avgHoldTime: data.avg_hold_time,
-          openTrades: trades.filter(t => t.status === 'open').length,
-          closedTrades: data.total_trades,
-          profitFactor: data.profit_factor || 0,
-          maxDrawdown: data.max_drawdown || 0,
-          sharpeRatio: data.sharpe_ratio || 0,
-          totalVolume: 0,
-          worstTrade: 0,
-        });
-      }
+      const data = await api.analytics.getPerformanceMetrics('1M');
+      setStats({
+        totalPnL: data.total_pnl,
+        totalTrades: data.total_trades,
+        winningTrades: data.winning_trades,
+        losingTrades: data.losing_trades,
+        winRate: data.win_rate,
+        avgWin: data.avg_win,
+        avgLoss: data.avg_loss,
+        bestTrade: data.largest_win,
+        avgHoldTime: data.avg_hold_time,
+        openTrades: trades.filter(t => t.status === 'open').length,
+        closedTrades: data.total_trades,
+        profitFactor: data.profit_factor || 0,
+        maxDrawdown: data.max_drawdown || 0,
+        sharpeRatio: data.sharpe_ratio || 0,
+        totalVolume: 0,
+        worstTrade: 0,
+      });
     } catch (error) {
       console.error('Error fetching real metrics:', error);
       // Fallback to calculated metrics only if API fails

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -161,14 +161,56 @@ export const api = {
 
   // Analytics endpoints
   analytics: {
-    getPerformanceMetrics: (timeframe = '1M') =>
-      authenticatedFetch(`${API_BASE_URL}/analytics/performance?timeframe=${timeframe}`),
+    getPerformanceMetrics: async (
+      timeframe: string = '1M',
+      portfolioId?: number,
+      signal?: AbortSignal
+    ) => {
+      const params = new URLSearchParams({ timeframe });
+      if (portfolioId) params.append('portfolio_id', portfolioId.toString());
+      const res = await authenticatedFetch(
+        `${API_BASE_URL}/analytics/performance?${params}`,
+        { signal }
+      );
+      if (!res.ok) {
+        throw new Error('Failed to fetch performance metrics');
+      }
+      return await res.json();
+    },
 
-    getTradeAnalytics: (timeframe = '3M') =>
-      authenticatedFetch(`${API_BASE_URL}/analytics/trade-analytics?timeframe=${timeframe}`),
+    getTradeAnalytics: async (
+      timeframe: string = '3M',
+      portfolioId?: number,
+      signal?: AbortSignal
+    ) => {
+      const params = new URLSearchParams({ timeframe });
+      if (portfolioId) params.append('portfolio_id', portfolioId.toString());
+      const res = await authenticatedFetch(
+        `${API_BASE_URL}/analytics/trade-analytics?${params}`,
+        { signal }
+      );
+      if (!res.ok) {
+        throw new Error('Failed to fetch trade analytics');
+      }
+      return await res.json();
+    },
 
-    getSummary: () =>
-      authenticatedFetch(`${API_BASE_URL}/analytics/summary`),
+    getSummary: async (
+      portfolioId?: number,
+      signal?: AbortSignal
+    ) => {
+      const params = new URLSearchParams();
+      if (portfolioId) params.append('portfolio_id', portfolioId.toString());
+      const query = params.toString() ? `?${params}` : '';
+      const res = await authenticatedFetch(
+        `${API_BASE_URL}/analytics/summary${query}`,
+        { signal }
+      );
+      if (!res.ok) {
+        throw new Error('Failed to fetch analytics summary');
+      }
+      return await res.json();
+    },
 
     getEquityCurve: async (
       timeframe: string = '3M',


### PR DESCRIPTION
## Summary
- parse analytics API responses and allow passing AbortSignals
- update analytics components to consume parsed data
- adapt trades page metrics to new API return types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run --environment jsdom --reporter=basic` *(fails: RiskDashboard > navigates between different sections)*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8c2f427b48331903ade3d8a839b4b