### PR TITLE
Add Alpaca trade validation and UI alerts

### DIFF
--- a/app/integrations/alpaca/client.py
+++ b/app/integrations/alpaca/client.py
@@ -35,7 +35,19 @@ def _in_regular_trading_hours(now: datetime | None = None) -> bool:
 
 
 class AlpacaClient:
-    def __init__(self) -> None:
+    def __init__(self, portfolio=None) -> None:
+        """Initialize client optionally using a specific portfolio.
+
+        If a portfolio instance is provided, credentials are loaded from it
+        before refreshing the underlying Alpaca trading client. This allows
+        per-portfolio API keys without relying on global state.
+        """
+        if portfolio is not None:
+            try:
+                settings.update_from_portfolio(portfolio)
+            except Exception:
+                logger.exception("Failed to update settings from portfolio")
+
         self.api_key = getattr(settings, "alpaca_api_key", None) or ""
         self.api_secret = getattr(settings, "alpaca_secret_key", None) or ""
         self.base_url = getattr(settings, "alpaca_base_url", None)
@@ -104,6 +116,10 @@ class AlpacaClient:
             )
             for p in positions
         ]
+
+    # Backwards compatibility alias used by some services
+    def get_all_positions(self):
+        return self.get_positions()
 
     def get_position(self, symbol: str):
         """Get single position with complete information"""

--- a/app/services/trade_validation.py
+++ b/app/services/trade_validation.py
@@ -1,0 +1,180 @@
+import logging
+from typing import Dict, List, Any
+from sqlalchemy.orm import Session
+
+from app.models.trades import Trade
+from app.models.user import User
+from app.services import portfolio_service
+from app.integrations.alpaca.client import AlpacaClient
+
+logger = logging.getLogger(__name__)
+
+
+class TradeValidator:
+    """Valida consistencia entre trades en BD y posiciones reales en Alpaca"""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def validate_user_trades(self, user_id: int) -> Dict[str, Any]:
+        """Valida todos los trades del usuario contra Alpaca"""
+        try:
+            user = self.db.query(User).filter(User.id == user_id).first()
+            active_portfolio = portfolio_service.get_active(self.db, user)
+            if not active_portfolio:
+                return {"error": "No active portfolio found"}
+
+            # Inicializar cliente Alpaca
+            alpaca_client = AlpacaClient(active_portfolio)
+
+            # Obtener trades abiertos en BD
+            open_trades = (
+                self.db.query(Trade)
+                .filter(
+                    Trade.user_id == user_id,
+                    Trade.portfolio_id == active_portfolio.id,
+                    Trade.status == "open",
+                )
+                .all()
+            )
+
+            # Obtener posiciones reales de Alpaca
+            try:
+                alpaca_positions = alpaca_client.get_all_positions()
+            except Exception as e:
+                logger.error(f"Error getting Alpaca positions: {e}")
+                alpaca_positions = []
+
+            validation_results = []
+            issues_found: List[Dict[str, Any]] = []
+
+            # Validar cada trade abierto
+            for trade in open_trades:
+                alpaca_position = None
+                for pos in alpaca_positions:
+                    if pos.symbol == trade.symbol:
+                        alpaca_position = pos
+                        break
+
+                trade_validation = self._validate_single_trade(trade, alpaca_position)
+                validation_results.append(trade_validation)
+
+                if trade_validation["has_issues"]:
+                    issues_found.append(trade_validation)
+
+            # Buscar posiciones en Alpaca que no están en BD
+            orphaned_positions = self._find_orphaned_positions(
+                alpaca_positions, open_trades
+            )
+
+            return {
+                "validation_results": validation_results,
+                "issues_found": issues_found,
+                "orphaned_positions": orphaned_positions,
+                "total_trades_validated": len(validation_results),
+                "issues_count": len(issues_found),
+                "orphaned_count": len(orphaned_positions),
+            }
+
+        except Exception as e:
+            logger.error(f"Error in trade validation: {e}")
+            return {"error": str(e)}
+
+    def _validate_single_trade(self, trade: Trade, alpaca_position) -> Dict[str, Any]:
+        """Valida un trade específico contra posición de Alpaca"""
+        issues: List[str] = []
+
+        # Si no hay posición en Alpaca pero el trade está abierto
+        if alpaca_position is None:
+            issues.append(
+                f"Trade {trade.id} shows as open but no position found in Alpaca"
+            )
+            return {
+                "trade_id": trade.id,
+                "symbol": trade.symbol,
+                "db_quantity": float(trade.quantity),
+                "alpaca_quantity": 0,
+                "db_pnl": float(trade.pnl or 0),
+                "alpaca_pnl": 0,
+                "has_issues": True,
+                "issues": issues,
+            }
+
+        # Comparar cantidades
+        db_qty = float(trade.quantity)
+        alpaca_qty = float(alpaca_position.qty)
+
+        if abs(db_qty - alpaca_qty) > 0.0001:
+            issues.append(f"Quantity mismatch: DB={db_qty}, Alpaca={alpaca_qty}")
+
+        # Comparar PnL
+        db_pnl = float(trade.pnl or 0)
+        alpaca_pnl = float(getattr(alpaca_position, "unrealized_pl", 0) or 0)
+
+        # Tolerancia del 5% o $1
+        pnl_diff = abs(db_pnl - alpaca_pnl)
+        if pnl_diff > max(1.0, abs(alpaca_pnl) * 0.05):
+            issues.append(f"PnL mismatch: DB={db_pnl:.2f}, Alpaca={alpaca_pnl:.2f}")
+
+        return {
+            "trade_id": trade.id,
+            "symbol": trade.symbol,
+            "db_quantity": db_qty,
+            "alpaca_quantity": alpaca_qty,
+            "db_pnl": db_pnl,
+            "alpaca_pnl": alpaca_pnl,
+            "has_issues": len(issues) > 0,
+            "issues": issues,
+        }
+
+    def _find_orphaned_positions(
+        self, alpaca_positions: List, open_trades: List[Trade]
+    ) -> List[Dict]:
+        """Encuentra posiciones en Alpaca que no están en la BD"""
+        orphaned: List[Dict[str, Any]] = []
+        trade_symbols = {trade.symbol for trade in open_trades}
+
+        for pos in alpaca_positions:
+            if pos.symbol not in trade_symbols:
+                orphaned.append(
+                    {
+                        "symbol": pos.symbol,
+                        "quantity": float(pos.qty),
+                        "unrealized_pnl": float(getattr(pos, "unrealized_pl", 0) or 0),
+                        "market_value": float(getattr(pos, "market_value", 0) or 0),
+                    }
+                )
+
+        return orphaned
+
+    def cleanup_orphaned_trades(self, user_id: int, dry_run: bool = True) -> Dict[str, Any]:
+        """Elimina trades huérfanos (que no existen en Alpaca)"""
+        validation = self.validate_user_trades(user_id)
+
+        if "error" in validation:
+            return validation
+
+        trades_to_remove = []
+        for issue in validation["issues_found"]:
+            # Si el trade no tiene posición en Alpaca, marcarlo para eliminación
+            if issue["alpaca_quantity"] == 0 and issue["alpaca_pnl"] == 0:
+                trades_to_remove.append(issue["trade_id"])
+
+        if dry_run:
+            return {
+                "dry_run": True,
+                "trades_to_remove": trades_to_remove,
+                "count": len(trades_to_remove),
+            }
+
+        # Eliminar trades huérfanos
+        removed_count = 0
+        for trade_id in trades_to_remove:
+            trade = self.db.query(Trade).filter(Trade.id == trade_id).first()
+            if trade:
+                self.db.delete(trade)
+                removed_count += 1
+
+        self.db.commit()
+
+        return {"removed_count": removed_count, "trades_removed": trades_to_remove}

--- a/frontend/src/components/ValidationAlert.tsx
+++ b/frontend/src/components/ValidationAlert.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface ValidationAlertProps {
+  issues: any[];
+  onClose: () => void;
+  onCleanup: (dryRun: boolean) => Promise<any>;
+}
+
+const ValidationAlert: React.FC<ValidationAlertProps> = ({ issues, onClose, onCleanup }) => {
+  if (issues.length === 0) return null;
+
+  return (
+    <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-yellow-800 font-semibold">
+          ⚠️ Validation Issues Found ({issues.length})
+        </h3>
+        <button onClick={onClose} className="text-yellow-600 hover:text-yellow-800">✕</button>
+      </div>
+
+      <div className="space-y-2 mb-4">
+        {issues.slice(0, 5).map((issue, idx) => (
+          <div key={idx} className="text-sm text-yellow-700">
+            • {issue.symbol}: {issue.issues.join(', ')}
+          </div>
+        ))}
+        {issues.length > 5 && (
+          <div className="text-sm text-yellow-600">
+            ...and {issues.length - 5} more issues
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={() => onCleanup(true)}
+          className="px-3 py-1 bg-yellow-100 text-yellow-800 rounded text-sm hover:bg-yellow-200"
+        >
+          Preview Cleanup
+        </button>
+        <button
+          onClick={() => onCleanup(false)}
+          className="px-3 py-1 bg-red-100 text-red-800 rounded text-sm hover:bg-red-200"
+        >
+          Clean Up Now
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ValidationAlert;


### PR DESCRIPTION
## Summary
- add Alpaca-backed trade validation service with cleanup helpers
- expose validation and cleanup endpoints
- sync trade PnL with real Alpaca positions
- show validation issues in Trades page with actionable alerts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.execution.bracket_order_integration_test')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8c64975d883318e75612ace547907