### PR TITLE
fix: show trades in list layout only

### DIFF
--- a/frontend/src/pages/trades/index.tsx
+++ b/frontend/src/pages/trades/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Filter, Download, RefreshCw, BarChart3, LayoutGrid, List as ListIcon } from 'lucide-react';
+import { Filter, Download, RefreshCw, BarChart3 } from 'lucide-react';
 import TradeCard from '../../components/trades/TradeCard';
 import TradeMetrics from '../../components/trades/TradeMetrics';
 import TradeFilters from '../../components/trades/TradeFilters';
@@ -73,7 +73,7 @@ const TradesPage: React.FC = () => {
   const [stats, setStats] = useState(defaultMetrics);
   const [loading, setLoading] = useState(true);
   const [showFilters, setShowFilters] = useState(false);
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  // const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [validationIssues, setValidationIssues] = useState<any[]>([]);
   const [showValidationPanel, setShowValidationPanel] = useState(false);
 
@@ -376,30 +376,7 @@ const TradesPage: React.FC = () => {
             <p className='text-slate-600 mt-1'>Comprehensive analysis of your trading performance and positions</p>
           </div>
           <div className='flex items-center space-x-3'>
-            <div className="flex items-center space-x-2">
-              <button
-                onClick={() => setViewMode('list')}
-                className={`p-2 rounded-lg transition-colors ${
-                  viewMode === 'list'
-                    ? 'bg-primary-100 text-primary-600'
-                    : 'text-slate-500 hover:text-slate-700 hover:bg-slate-100'
-                }`}
-                title="List View"
-              >
-                <ListIcon className="w-5 h-5" />
-              </button>
-              <button
-                onClick={() => setViewMode('grid')}
-                className={`p-2 rounded-lg transition-colors ${
-                  viewMode === 'grid'
-                    ? 'bg-primary-100 text-primary-600'
-                    : 'text-slate-500 hover:text-slate-700 hover:bg-slate-100'
-                }`}
-                title="Grid View"
-              >
-                <LayoutGrid className="w-5 h-5" />
-              </button>
-            </div>
+            {/* View mode toggle removed */}
             <button onClick={() => setShowFilters(!showFilters)} className={`btn-secondary ${showFilters ? 'bg-primary-50 text-primary-700 border-primary-200' : ''}`}>
               <Filter className='w-4 h-4 mr-2' />
               Filters
@@ -483,7 +460,7 @@ const TradesPage: React.FC = () => {
                 )}
               </div>
             ) : (
-              <div className={`${viewMode === 'grid' ? 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-2 gap-6 space-y-0' : 'space-y-3'}`}>
+              <div className="space-y-3">
                 {filteredTrades.map(trade => (
                   <TradeCard
                     key={trade.id}
@@ -500,7 +477,6 @@ const TradesPage: React.FC = () => {
                       status: trade.status,
                       strategy_id: trade.strategy_id,
                     }}
-                    compact={viewMode === 'list'}
                     onClose={handleCloseTrade}
                     onViewDetails={(trade) => {
                       console.log('View details for trade:', trade.id);


### PR DESCRIPTION
## Summary
- remove grid/list toggle and related state
- render trades as a single vertical list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 71 errors, 6 warnings)*
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cbf3ab6c8331bb090d13b7ce4232