### PR TITLE
Fix orders endpoint and include execution router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from app.api.v1.portfolio_performance import (
     router as portfolio_performance_router,
 )
 from app.api.ws import router as ws_router
-from app.api.v1 import auth, trades, strategies, portfolio, risk, system, positions, reports
+from app.api.v1 import auth, trades, strategies, portfolio, risk, system, positions, reports, execution
 from app.database import SessionLocal
 from app.services import portfolio_service
 from app.integrations import refresh_broker_client
@@ -48,6 +48,7 @@ app.include_router(system.router, prefix="/api/v1/system", tags=["system"])
 app.include_router(exit_rules_router, prefix="/api/v1/exit-rules", tags=["Exit Rules"])
 app.include_router(bracket_orders_router, prefix="/api/v1/bracket-orders", tags=["Bracket Orders"])
 app.include_router(analytics_router, prefix="/api/v1/analytics", tags=["analytics"])
+app.include_router(execution.router, prefix="/api/v1/execution", tags=["execution"])
 app.include_router(positions.router, prefix="/api/v1", tags=["positions"])
 app.include_router(reports.router, prefix="/api/v1", tags=["reports"])
 app.include_router(ws_router)

--- a/frontend/src/pages/orders/index.tsx
+++ b/frontend/src/pages/orders/index.tsx
@@ -99,9 +99,8 @@ const OrdersPage: React.FC = () => {
   const fetchOrders = async () => {
     try {
       setLoading(true);
-      const response = await authenticatedFetch('/api/v1/orders/my');
+      const response = await authenticatedFetch('/api/v1/execution/orders/my');
       const data = await response.json();
-      console.log('Orders API Response:', data); // DEBUG - remover después
 
       const parsed = Array.isArray(data.orders)
         ? data.orders.map((o: any) => ({
@@ -124,7 +123,6 @@ const OrdersPage: React.FC = () => {
           }))
         : [];
 
-      console.log('Parsed orders:', parsed.length, 'orders'); // DEBUG - remover después
       setOrders(parsed);
     } catch (error) {
       console.error('Error fetching orders:', error);


### PR DESCRIPTION
## Summary
- update orders page to fetch from execution orders endpoint
- wire up execution router in FastAPI app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 77 problems)*
- `pytest` *(fails: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3eb6b6e48331b79c4f7e60b1383a