### PR TITLE
Fix numeric IDs breaking orders page

### DIFF
--- a/frontend/src/pages/orders/index.tsx
+++ b/frontend/src/pages/orders/index.tsx
@@ -104,7 +104,7 @@ const OrdersPage: React.FC = () => {
 
       const parsed = Array.isArray(data.orders)
         ? data.orders.map((o: any) => ({
-            id: o.id,
+            id: o.id?.toString(),
             symbol: o.symbol,
             side: o.side,
             order_type: o.order_type,
@@ -117,7 +117,7 @@ const OrdersPage: React.FC = () => {
             submitted_at: o.created_at, // API retorna 'created_at', no 'submitted_at'
             filled_at: o.filled_at,
             time_in_force: o.time_in_force,
-            strategy_id: o.signal_id, // API retorna 'signal_id'
+            strategy_id: o.signal_id ? o.signal_id.toString() : undefined, // API retorna 'signal_id'
             strategy_name: undefined, // No viene en la respuesta
             client_order_id: o.client_order_id
           }))


### PR DESCRIPTION
## Summary
- ensure order IDs and strategy IDs from API are treated as strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm run build`
- `pytest tests/test_order_manager_position_size.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba40f642108331a4d469b1140761c5