### PR TITLE
Handle Infinity profit factors in PortfolioAnalytics

### DIFF
--- a/frontend/src/components/analytics/PortfolioAnalytics.tsx
+++ b/frontend/src/components/analytics/PortfolioAnalytics.tsx
@@ -283,16 +283,16 @@ const PortfolioAnalytics: React.FC = () => {
 
             <MetricCard
               title="Profit Factor"
-              value={pf > 0 && isFinite(pf) ? pf.toFixed(2) : '∞'}
+              value={isFinite(pf) ? pf.toFixed(2) : '∞'}
               subtitle={
-                pf > 0 && isFinite(pf)
-                  ? pf > 1
-                    ? 'Profitable'
-                    : 'Unprofitable'
-                  : 'No losing trades'
+                pf === Infinity
+                  ? 'No losing trades'
+                  : pf > 1
+                  ? 'Profitable'
+                  : 'Unprofitable'
               }
               icon={Trophy}
-              colorClass={pf > 1 ? 'text-green-600' : 'text-red-600'}
+              colorClass={pf !== Infinity && pf <= 1 ? 'text-red-600' : 'text-green-600'}
             />
 
             <MetricCard


### PR DESCRIPTION
## Summary
- Show numeric profit factor for negative values and ∞ when appropriate
- Distinguish unprofitable vs no losing trades in profit factor subtitle
- Ensure color styling reflects non-positive profit factors

## Testing
- `npm test` (fails: Missing script: "test")
- `npx vitest run` (fails: document is not defined)
- `npm run lint` (fails: Unexpected any)
- `pytest` (fails: ModuleNotFoundError: No module named 'app.execution.order_processor')

------
https://chatgpt.com/codex/tasks/task_e_68bba42449b4833182cc38f56acc7d9e