### PR TITLE
Optimize trade metric counts and add tests

### DIFF
--- a/tests/analytics/test_metrics_calculations.py
+++ b/tests/analytics/test_metrics_calculations.py
@@ -74,7 +74,9 @@ def test_calculate_win_rate(db_session, test_user, test_portfolio):
     db_session.commit()
 
     base_query = db_session.query(Trade).filter(Trade.user_id == test_user.id)
-    win_rate = analytics._calculate_win_rate(base_query)
+    total_trades = base_query.count()
+    winning_trades = base_query.filter(Trade.pnl > 0).count()
+    win_rate = analytics._calculate_win_rate(total_trades, winning_trades)
 
     assert win_rate == 66.67
 


### PR DESCRIPTION
## Summary
- Avoid repeated count queries in portfolio analytics by aggregating trade outcomes and statuses in single queries
- Refactor win-rate calculation to reuse precomputed counts
- Add tests verifying trade count breakdown and update existing win rate test

## Testing
- `pytest tests/analytics/test_portfolio_analytics.py::test_get_performance_metrics_counts -q`
- `pytest tests/analytics/test_portfolio_analytics.py -q`
- `pytest tests/analytics/test_metrics_calculations.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bba56ffaf083319a49a363325af33d