### PR TITLE
feat: Add Exit Rules Manager to sidebar navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,6 +65,8 @@ const AuthenticatedApp: React.FC = () => {
         return <TradesPage />;
       case 'strategies':
         return <StrategiesPage />;
+      case 'exit-rules':
+        return <ExitRulesManager />;
       case 'risk':
         return <RiskDashboard />;
       case 'analytics':

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -101,6 +101,7 @@ const Header: React.FC<HeaderProps> = ({
     orders: 'Order Management',
     trades: 'Trade History',
     strategies: 'Strategy Manager',
+    'exit-rules': 'Exit Rules Manager',
     risk: 'Risk Dashboard',
     analytics: 'Portfolio Analytics',
     settings: 'Account Settings'

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -6,7 +6,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 
-export type Page = 'dashboard' | 'signals' | 'orders' | 'trades' | 'strategies' | 'risk' | 'analytics' | 'settings';
+export type Page = 'dashboard' | 'signals' | 'orders' | 'trades' | 'strategies' | 'exit-rules' | 'risk' | 'analytics' | 'settings';
 
 interface SidebarProps {
   currentPage: Page;
@@ -74,6 +74,13 @@ const Sidebar: React.FC<SidebarProps> = ({
           id: 'strategies' as Page,
           name: 'Strategies',
           icon: Brain,
+          badge: null,
+          category: 'trading' as const
+        },
+        {
+          id: 'exit-rules' as Page,
+          name: 'Exit Rules',
+          icon: Settings,
           badge: null,
           category: 'trading' as const
         }


### PR DESCRIPTION
## 🚀 Feature: Exit Rules Manager in Sidebar

### What this PR does:
- Adds **Exit Rules Manager** to the sidebar navigation menu
- Places it in the **Trading** section alongside Signals, Orders, Trades, and Strategies
- Users can now easily access trailing stop, stop loss, and take profit configuration

### Changes made:

#### 📁 `frontend/src/components/layout/Sidebar.tsx`
- Added `'exit-rules'` to the `Page` type definition
- Added Exit Rules menu item in Trading section with Settings icon

#### 📁 `frontend/src/App.tsx`
- Added case for `'exit-rules'` in `renderCurrentPage()` function
- Routes to `<ExitRulesManager />` component when selected

#### 📁 `frontend/src/components/layout/Header.tsx`
- Updated `pageNames` to display "Exit Rules Manager" in header

### 🎯 User Experience:
- **Before**: Users had to manually navigate to `/exit-rules` URL
- **After**: Users can click "Exit Rules" in the sidebar Trading section

### 🧪 Testing:
1. Start the frontend application
2. Navigate to the Trading section in sidebar
3. Click on "Exit Rules" menu item
4. Verify Exit Rules Manager loads correctly
5. Verify header shows "Exit Rules Manager" title

### 📸 Preview:
The Exit Rules Manager allows users to:
- Configure stop loss percentages (0.1% - 50%)
- Set take profit percentages (0.1% - 100%)
- Adjust trailing stop percentages (0.1% - 50%)
- Enable/disable trailing stops
- Set risk/reward ratios (0.5 - 10.0)
- Calculate exit prices for testing

---

**Ready for review and testing!** 🚀

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author