### PR TITLE
Revamp trades page layout with compact metrics and chart

### DIFF
--- a/frontend/src/components/dashboard/AlpacaStyleChart.tsx
+++ b/frontend/src/components/dashboard/AlpacaStyleChart.tsx
@@ -26,15 +26,17 @@ interface PortfolioPerformanceData {
 
 interface AlpacaStyleChartProps {
   loading?: boolean;
+  compact?: boolean;
 }
 
 const AlpacaStyleChart: React.FC<AlpacaStyleChartProps> = ({
-  loading = false
+  loading = false,
+  compact = false
 }) => {
   const [data, setData] = useState<PortfolioPerformanceData | null>(null);
   const [selectedTimeframe, setSelectedTimeframe] = useState<
     '1D' | '1W' | '1M' | '3M' | '1Y' | 'ALL'
-  >('1D');
+  >(compact ? '1M' : '1D');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -135,19 +137,23 @@ const AlpacaStyleChart: React.FC<AlpacaStyleChartProps> = ({
     return (
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <div className="animate-pulse">
-          <div className="flex items-center justify-between mb-6">
-            <div>
-              <div className="h-4 bg-gray-200 rounded w-32 mb-2"></div>
-              <div className="h-8 bg-gray-200 rounded w-48 mb-1"></div>
-              <div className="h-4 bg-gray-200 rounded w-40"></div>
+          {!compact ? (
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <div className="h-4 bg-gray-200 rounded w-32 mb-2"></div>
+                <div className="h-8 bg-gray-200 rounded w-48 mb-1"></div>
+                <div className="h-4 bg-gray-200 rounded w-40"></div>
+              </div>
+              <div className="flex space-x-2">
+                {timeframes.map((tf) => (
+                  <div key={tf.key} className="h-8 w-10 bg-gray-200 rounded"></div>
+                ))}
+              </div>
             </div>
-            <div className="flex space-x-2">
-              {timeframes.map((tf) => (
-                <div key={tf.key} className="h-8 w-10 bg-gray-200 rounded"></div>
-              ))}
-            </div>
-          </div>
-          <div className="h-64 bg-gray-200 rounded"></div>
+          ) : (
+            <div className="h-4 bg-gray-200 rounded w-32 mb-4"></div>
+          )}
+          <div className={compact ? 'h-40 bg-gray-200 rounded' : 'h-64 bg-gray-200 rounded'}></div>
         </div>
       </div>
     );
@@ -167,53 +173,62 @@ const AlpacaStyleChart: React.FC<AlpacaStyleChartProps> = ({
 
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h3 className="text-sm font-medium text-gray-600 mb-2">
-            Your portfolio
-          </h3>
-          <div className="flex items-center space-x-2">
-            <span className="text-3xl font-bold text-gray-900">
-              {formatCurrency(data.current_value)}
-            </span>
-            <span
-              className={`text-lg font-medium ${
-                isPositive ? 'text-green-600' : 'text-red-600'
-              }`}
-            >
-              {isPositive ? '+' : ''}
-              {data.change_percent}%
-            </span>
+      {!compact ? (
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <h3 className="text-sm font-medium text-gray-600 mb-2">
+              Your portfolio
+            </h3>
+            <div className="flex items-center space-x-2">
+              <span className="text-3xl font-bold text-gray-900">
+                {formatCurrency(data.current_value)}
+              </span>
+              <span
+                className={`text-lg font-medium ${
+                  isPositive ? 'text-green-600' : 'text-red-600'
+                }`}
+              >
+                {isPositive ? '+' : ''}
+                {data.change_percent}%
+              </span>
+            </div>
+            <div className="text-sm text-gray-500 mt-1">
+              {lastUpdated.toLocaleDateString('en-US', {
+                month: 'long',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true,
+                timeZoneName: 'short'
+              })}
+            </div>
           </div>
-          <div className="text-sm text-gray-500 mt-1">
-            {lastUpdated.toLocaleDateString('en-US', {
-              month: 'long',
-              day: 'numeric',
-              hour: 'numeric',
-              minute: '2-digit',
-              hour12: true,
-              timeZoneName: 'short'
-            })}
+          <div className="flex space-x-1 bg-gray-100 rounded-lg p-1">
+            {timeframes.map((tf) => (
+              <button
+                key={tf.key}
+                onClick={() => setSelectedTimeframe(tf.key)}
+                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                  selectedTimeframe === tf.key
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                {tf.label}
+              </button>
+            ))}
           </div>
         </div>
-        <div className="flex space-x-1 bg-gray-100 rounded-lg p-1">
-          {timeframes.map((tf) => (
-            <button
-              key={tf.key}
-              onClick={() => setSelectedTimeframe(tf.key)}
-              className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
-                selectedTimeframe === tf.key
-                  ? 'bg-white text-gray-900 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              {tf.label}
-            </button>
-          ))}
+      ) : (
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium text-gray-600">Portfolio Value</span>
+          <span className="text-lg font-bold text-gray-900">
+            {formatCurrency(data.current_value)}
+          </span>
         </div>
-      </div>
+      )}
 
-      <div className="h-64 -mx-2">
+      <div className={compact ? 'h-40 -mx-2' : 'h-64 -mx-2'}>
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data.historical_data}>
             <XAxis

--- a/frontend/src/components/trades/CompactStrategyPerformance.tsx
+++ b/frontend/src/components/trades/CompactStrategyPerformance.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface StrategyStat {
+  id: string;
+  name: string;
+  totalPnL: number;
+  winRate: number;
+  trades: number;
+}
+
+interface CompactStrategyPerformanceProps {
+  strategyStats: StrategyStat[];
+}
+
+const CompactStrategyPerformance: React.FC<CompactStrategyPerformanceProps> = ({ strategyStats }) => {
+  if (strategyStats.length === 0) return null;
+  return (
+    <div className="card p-4">
+      <h3 className="text-base font-semibold text-slate-900 mb-3">Performance by Strategy</h3>
+      <div className="space-y-2">
+        {strategyStats.map((s) => (
+          <div key={s.id} className="flex justify-between items-center py-2 px-3 rounded-lg bg-slate-50">
+            <div className="flex flex-col">
+              <span className="font-medium text-slate-700 text-sm">{s.name}</span>
+              <span className="text-xs text-slate-500">Win Rate: {s.winRate.toFixed(1)}% ({s.trades} trades)</span>
+            </div>
+            <span className={`text-sm font-semibold ${s.totalPnL >= 0 ? 'text-success-600' : 'text-error-600'}`}>
+              {s.totalPnL >= 0 ? '+' : ''}${Math.abs(s.totalPnL).toFixed(2)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CompactStrategyPerformance;

--- a/frontend/src/components/trades/CompactTradeMetrics.tsx
+++ b/frontend/src/components/trades/CompactTradeMetrics.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+interface TradeStats {
+  totalPnL: number;
+  winRate: number;
+  avgWin: number;
+  avgLoss: number;
+  bestTrade: number;
+  profitFactor: number;
+  sharpeRatio: number;
+  maxDrawdown: number;
+}
+
+interface CompactTradeMetricsProps {
+  stats: TradeStats;
+}
+
+const CompactTradeMetrics: React.FC<CompactTradeMetricsProps> = ({ stats }) => (
+  <div className="card p-4 mb-4">
+    <h3 className="text-base font-semibold text-slate-900 mb-3">Metrics</h3>
+    <div className="space-y-3">
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Total P&L</span>
+        <span className={`font-semibold ${stats.totalPnL >= 0 ? 'text-success-600' : 'text-error-600'}`}>
+          {stats.totalPnL >= 0 ? '+' : ''}${Math.abs(stats.totalPnL).toFixed(2)}
+        </span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Win Rate</span>
+        <span className="font-semibold text-slate-900">{stats.winRate.toFixed(1)}%</span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Avg Win</span>
+        <span className="font-semibold text-success-600">${stats.avgWin.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Avg Loss</span>
+        <span className="font-semibold text-error-600">${Math.abs(stats.avgLoss).toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Best Trade</span>
+        <span className="font-semibold text-success-600">+${stats.bestTrade.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Profit Factor</span>
+        <span className={`font-semibold ${stats.profitFactor >= 1 ? 'text-success-600' : 'text-error-600'}`}>
+          {stats.profitFactor.toFixed(2)}
+        </span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Sharpe Ratio</span>
+        <span className="font-semibold text-slate-900">{stats.sharpeRatio.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600">Max Drawdown</span>
+        <span className="font-semibold text-error-600">-{Math.abs(stats.maxDrawdown).toFixed(2)}%</span>
+      </div>
+    </div>
+  </div>
+);
+
+export default CompactTradeMetrics;

--- a/frontend/src/pages/trades/index.tsx
+++ b/frontend/src/pages/trades/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Filter, Download, RefreshCw, BarChart3 } from 'lucide-react';
 import TradeCard from '../../components/trades/TradeCard';
-import TradeMetrics from '../../components/trades/TradeMetrics';
 import TradeFilters from '../../components/trades/TradeFilters';
+import CompactTradeMetrics from '../../components/trades/CompactTradeMetrics';
+import CompactStrategyPerformance from '../../components/trades/CompactStrategyPerformance';
 import AlpacaStyleChart from '../../components/dashboard/AlpacaStyleChart';
 import ValidationAlert from '../../components/ValidationAlert';
 import { api } from '../../services/api';
@@ -377,26 +378,11 @@ const TradesPage: React.FC = () => {
             <p className='text-slate-600 mt-1'>Comprehensive analysis of your trading performance and positions</p>
           </div>
           <div className='flex items-center space-x-3'>
-            {/* View mode toggle removed */}
-            <button onClick={() => setShowFilters(!showFilters)} className={`btn-secondary ${showFilters ? 'bg-primary-50 text-primary-700 border-primary-200' : ''}`}>
-              <Filter className='w-4 h-4 mr-2' />
-              Filters
-            </button>
-            <button onClick={exportTrades} className='btn-ghost'>
-              <Download className='w-4 h-4 mr-2' />
-              Export
-            </button>
-            <button onClick={() => { fetchTrades(); fetchRealMetrics(); }} className='btn-secondary'>
-              <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
-              Refresh
-            </button>
             <button onClick={validateTrades} className='btn btn-warning'>
               Validate with Alpaca
             </button>
           </div>
         </div>
-
-        <TradeMetrics metrics={stats} loading={loading} />
 
         {showValidationPanel && (
           <ValidationAlert
@@ -406,86 +392,101 @@ const TradesPage: React.FC = () => {
           />
         )}
 
-        {/* Portfolio Performance Chart */}
-        <div className="card p-6">
-          <div className="flex items-center justify-between mb-6">
-            <div>
-              <h3 className="text-lg font-semibold text-slate-900">Portfolio Performance</h3>
-              <p className="text-sm text-slate-600">Track your trading performance over time</p>
+        <div className='grid grid-cols-12 gap-6 min-h-screen'>
+          <div className='col-span-12 lg:col-span-4'>
+            <div className='card p-4'>
+              <h3 className='text-base font-semibold text-slate-900 mb-3'>Portfolio Performance</h3>
+              <div className='h-48'>
+                <AlpacaStyleChart loading={loading} compact={true} />
+              </div>
             </div>
           </div>
 
-          {/* Usar el mismo componente que funciona en Dashboard */}
-          <AlpacaStyleChart loading={loading} />
-        </div>
-
-        {strategyStats.length > 0 && (
-          <div className='card p-6'>
-            <h3 className='text-lg font-semibold text-slate-900 mb-4'>Performance by Strategy</h3>
-            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-              {strategyStats.map(s => (
-                <div key={s.id} className='p-4 rounded-xl bg-slate-50'>
-                  <div className='flex items-center justify-between mb-2'>
-                    <span className='font-medium text-slate-700'>{s.name}</span>
-                    <span className={`text-sm font-semibold ${s.totalPnL >= 0 ? 'text-success-600' : 'text-error-600'}`}>
-                      {s.totalPnL >= 0 ? '+' : ''}${Math.abs(s.totalPnL).toFixed(2)}
-                    </span>
-                  </div>
-                  <div className='text-xs text-slate-500'>Win Rate: {s.winRate.toFixed(1)}% ({s.trades} trades)</div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <div className='grid grid-cols-1 lg:grid-cols-4 gap-6'>
-          {showFilters && (
-            <div className='lg:col-span-1'>
-              <TradeFilters filters={filters} onFiltersChange={setFilters} strategies={strategies} onReset={resetFilters} />
-            </div>
-          )}
-          <div className={showFilters ? 'lg:col-span-3' : 'lg:col-span-4'}>
-            {filteredTrades.length === 0 ? (
-              <div className='card p-12 text-center'>
-                <div className='w-20 h-20 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-6'>
-                  <BarChart3 className='w-10 h-10 text-slate-400' />
-                </div>
-                <h3 className='text-xl font-semibold text-slate-900 mb-2'>No Trades Found</h3>
-                <p className='text-slate-600 mb-6'>
-                  {trades.length === 0 ? "You haven't executed any trades yet. Your trading history will appear here once you start trading." : 'No trades match your current filters. Try adjusting your search criteria.'}
-                </p>
-                {trades.length > 0 && (
-                  <button onClick={resetFilters} className='btn-secondary'>
-                    Clear Filters
+          <div className='col-span-12 lg:col-span-4'>
+            {showFilters && (
+              <div className='mb-4'>
+                <TradeFilters filters={filters} onFiltersChange={setFilters} strategies={strategies} onReset={resetFilters} />
+              </div>
+            )}
+            <div className='card p-4'>
+              <div className='flex items-center justify-between mb-4'>
+                <h3 className='text-base font-semibold text-slate-900'>Recent Trades</h3>
+                <div className='flex items-center space-x-2'>
+                  <button
+                    onClick={() => setShowFilters(!showFilters)}
+                    className={`btn-ghost text-xs px-2 py-1 ${showFilters ? 'bg-primary-50 text-primary-700 border-primary-200' : ''}`}
+                  >
+                    <Filter className='w-3 h-3 mr-1' />
+                    Filters
                   </button>
+                  <button onClick={exportTrades} className='btn-ghost text-xs px-2 py-1'>
+                    <Download className='w-3 h-3 mr-1' />
+                    Export
+                  </button>
+                  <button
+                    onClick={() => {
+                      fetchTrades();
+                      fetchRealMetrics();
+                    }}
+                    className='btn-secondary text-xs px-2 py-1'
+                  >
+                    <RefreshCw className={`w-3 h-3 mr-1 ${loading ? 'animate-spin' : ''}`} />
+                    Refresh
+                  </button>
+                </div>
+              </div>
+              <div className='overflow-auto' style={{ maxHeight: '500px' }}>
+                {filteredTrades.length === 0 ? (
+                  <div className='text-center p-6'>
+                    <div className='w-20 h-20 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-6'>
+                      <BarChart3 className='w-10 h-10 text-slate-400' />
+                    </div>
+                    <h3 className='text-xl font-semibold text-slate-900 mb-2'>No Trades Found</h3>
+                    <p className='text-slate-600 mb-6'>
+                      {trades.length === 0
+                        ? "You haven't executed any trades yet. Your trading history will appear here once you start trading."
+                        : 'No trades match your current filters. Try adjusting your search criteria.'}
+                    </p>
+                    {trades.length > 0 && (
+                      <button onClick={resetFilters} className='btn-secondary'>
+                        Clear Filters
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  <div className='space-y-3'>
+                    {filteredTrades.map(trade => (
+                      <TradeCard
+                        key={trade.id}
+                        trade={{
+                          id: trade.id,
+                          symbol: trade.symbol,
+                          side: trade.action,
+                          quantity: trade.quantity,
+                          entry_price: trade.entry_price,
+                          exit_price: trade.exit_price,
+                          realized_pnl: trade.pnl,
+                          entry_time: trade.opened_at,
+                          exit_time: trade.closed_at,
+                          status: trade.status,
+                          strategy_id: trade.strategy_id,
+                        }}
+                        onClose={handleCloseTrade}
+                        onViewDetails={(trade) => {
+                          console.log('View details for trade:', trade.id);
+                        }}
+                      />
+                    ))}
+                  </div>
                 )}
               </div>
-            ) : (
-              <div className="space-y-3">
-                {filteredTrades.map(trade => (
-                  <TradeCard
-                    key={trade.id}
-                    trade={{
-                      id: trade.id,
-                      symbol: trade.symbol,
-                      side: trade.action,
-                      quantity: trade.quantity,
-                      entry_price: trade.entry_price,
-                      exit_price: trade.exit_price,
-                      realized_pnl: trade.pnl,
-                      entry_time: trade.opened_at,
-                      exit_time: trade.closed_at,
-                      status: trade.status,
-                      strategy_id: trade.strategy_id,
-                    }}
-                    onClose={handleCloseTrade}
-                    onViewDetails={(trade) => {
-                      console.log('View details for trade:', trade.id);
-                      // Aquí puedes añadir la lógica para mostrar detalles
-                    }}
-                  />
-                ))}
-              </div>
+            </div>
+          </div>
+
+          <div className='col-span-12 lg:col-span-4 space-y-4'>
+            <CompactTradeMetrics stats={stats} />
+            {strategyStats.length > 0 && (
+              <CompactStrategyPerformance strategyStats={strategyStats} />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Refactor trades page to a three-column layout
- Add compact portfolio chart, metrics list, and strategy performance components
- Support compact mode in AlpacaStyleChart

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bda7b3a9608331ba33f3a7a1161c1a