### PR TITLE
Fix trades page layout in frontend

### DIFF
--- a/frontend/src/pages/trades/index.tsx
+++ b/frontend/src/pages/trades/index.tsx
@@ -393,7 +393,7 @@ const TradesPage: React.FC = () => {
         )}
 
         <div className='grid grid-cols-12 gap-6 min-h-screen'>
-          <div className='col-span-12 lg:col-span-4'>
+          <div className='col-span-12 lg:col-span-8'>
             <div className='card p-4'>
               <h3 className='text-base font-semibold text-slate-900 mb-3'>Portfolio Performance</h3>
               <div className='h-48'>
@@ -402,7 +402,14 @@ const TradesPage: React.FC = () => {
             </div>
           </div>
 
-          <div className='col-span-12 lg:col-span-4'>
+          <div className='col-span-12 lg:col-span-4 lg:row-span-2 space-y-4'>
+            <CompactTradeMetrics stats={stats} />
+            {strategyStats.length > 0 && (
+              <CompactStrategyPerformance strategyStats={strategyStats} />
+            )}
+          </div>
+
+          <div className='col-span-12 lg:col-span-8'>
             {showFilters && (
               <div className='mb-4'>
                 <TradeFilters filters={filters} onFiltersChange={setFilters} strategies={strategies} onReset={resetFilters} />
@@ -481,13 +488,6 @@ const TradesPage: React.FC = () => {
                 )}
               </div>
             </div>
-          </div>
-
-          <div className='col-span-12 lg:col-span-4 space-y-4'>
-            <CompactTradeMetrics stats={stats} />
-            {strategyStats.length > 0 && (
-              <CompactStrategyPerformance strategyStats={strategyStats} />
-            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Ensure trades list appears below portfolio performance chart
- Keep metrics sidebar fixed on the right across rows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: document is not defined in multiple tests)*
- `npm run lint` *(fails: 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bda9f93bfc833198b9da99605862ad