### PR TITLE
Remove unused setters for sorting state

### DIFF
--- a/frontend/src/components/signals/ProfessionalSignalsPage.tsx
+++ b/frontend/src/components/signals/ProfessionalSignalsPage.tsx
@@ -44,8 +44,8 @@ const ProfessionalSignalsPage: React.FC<ProfessionalSignalsPageProps> = ({
 }) => {
   const [filter, setFilter] = useState('all');
   const [searchTerm, setSearchTerm] = useState('');
-  const [sortBy, setSortBy] = useState('timestamp');
-  const [sortOrder, setSortOrder] = useState('desc');
+  const [sortBy] = useState<keyof Signal>('timestamp');
+  const [sortOrder] = useState<'asc' | 'desc'>('desc');
 
   const filteredSignals = signals
     .filter(signal => {


### PR DESCRIPTION
## Summary
- remove unused setter functions from sorting state in `ProfessionalSignalsPage`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07c1ed4088331842bd9056a42fef6