### PR TITLE
Fix timestamp sorting order

### DIFF
--- a/frontend/src/components/signals/ProfessionalSignalsPage.tsx
+++ b/frontend/src/components/signals/ProfessionalSignalsPage.tsx
@@ -60,7 +60,9 @@ const ProfessionalSignalsPage: React.FC<ProfessionalSignalsPageProps> = ({
       const direction = sortOrder === 'asc' ? 1 : -1;
 
       if (sortBy === 'timestamp') {
-        return direction * (new Date(bVal as string).getTime() - new Date(aVal as string).getTime());
+        return sortOrder === 'asc'
+          ? new Date(aVal as string).getTime() - new Date(bVal as string).getTime()
+          : new Date(bVal as string).getTime() - new Date(aVal as string).getTime();
       }
       return direction * ((aVal as number) > (bVal as number) ? 1 : -1);
     });


### PR DESCRIPTION
## Summary
- ensure timestamp sorting order uses correct ascending and descending comparisons so newest signals appear first when sort order is `desc`

## Testing
- `npm test` (fails: Missing script "test")
- `npx vitest run` (fails: ReferenceError: document is not defined)
- `npm run lint` (fails: ESLint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68c07f01d8b88331ac113fdda375ed3f