### PR TITLE
Make table cells auto-expand for multiline content

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -16,6 +16,27 @@
     font-feature-settings: 'cv11', 'ss01';
     font-variation-settings: 'opsz' 32;
   }
+
+
+  /* Make table rows/cells grow naturally with multiline content */
+  table {
+    border-collapse: collapse;
+    table-layout: auto;
+  }
+
+  th,
+  td {
+    vertical-align: top;
+  }
+
+  td {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.45;
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
### Motivation
- Table cells across the app were clipping multiline content because table/cell styles forced fixed heights and prevented natural wrapping, causing important text to be cut off.

### Description
- Added global base styles in `frontend/src/styles/globals.css` to make tables use `table-layout: auto` and `border-collapse: collapse` so rows can grow with their content.
- Set `th, td` to `vertical-align: top` and updated `td` to allow wrapping with `white-space: normal`, `overflow-wrap: anywhere` and `word-break: break-word` plus a slightly increased `line-height` and small vertical `padding` to give extra breathing room and avoid visual clipping.

### Testing
- Successfully built the frontend with `cd frontend && npm run build`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11a95fa548331b396cba5a99cba80)