### PR TITLE
Allow table rows/cells and ARIA grid cells to auto-size and wrap multiline content

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -16,6 +16,60 @@
     font-feature-settings: 'cv11', 'ss01';
     font-variation-settings: 'opsz' 32;
   }
+
+
+  /* Make table rows/cells grow naturally with multiline content */
+  table {
+    border-collapse: collapse;
+    table-layout: auto;
+  }
+
+  tr {
+    height: auto !important;
+  }
+
+  th,
+  td {
+    vertical-align: top;
+    height: auto !important;
+    overflow: visible;
+  }
+
+  td {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.5;
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+  }
+
+  /* Force wrappers commonly used inside table cells to allow wrapping. */
+  td > * {
+    white-space: inherit;
+    overflow: visible;
+    text-overflow: clip;
+    max-height: none;
+  }
+
+  /* Defensive rule for div-based grids that use ARIA roles instead of <table>. */
+  [role='row'] {
+    min-height: fit-content;
+    height: auto !important;
+  }
+
+  [role='gridcell'],
+  [role='cell'] {
+    white-space: normal !important;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.5;
+    overflow: visible !important;
+    height: auto !important;
+    min-height: fit-content;
+    padding-top: 0.35rem;
+    padding-bottom: 0.35rem;
+  }
 }
 
 @layer components {
@@ -118,4 +172,3 @@
     display: none;
   }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent table cells and rows from truncating or collapsing when they contain multiline or long unbroken content.
- Ensure div-based grids that use ARIA roles behave the same as native tables and allow wrapping and natural height growth.

### Description
- Added base CSS rules for `table`, `tr`, `th`, and `td` to use `table-layout: auto`, `height: auto`, `overflow: visible`, and top vertical alignment so rows grow with content.
- Updated `td` to allow wrapping with `white-space: normal`, `overflow-wrap: anywhere`, `word-break: break-word`, adjusted `line-height`, and cell padding for improved readability.
- Added rules for wrapper elements inside cells (`td > *`) to inherit `white-space` and disable clipping so common inner elements can wrap naturally.
- Added defensive rules for ARIA-based grids with `role='row'`, `role='gridcell'`, and `role='cell'` to mirror the table-cell behavior and ensure consistent wrapping and height handling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11a95fa548331b396cba5a99cba80)